### PR TITLE
Clean library after sync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The goal of this addon is to harness Kodi's excellent browsing and metadata scra
 - 🌐 If the movie can't be played within Kodi, the user is prompted to open it in their browser (tested on macOS only)
 - 🈯 Supports display of titles and descriptions in the languages supported by Mubi
 - 🔖 Retrieves and displays your MUBI watchlist within Kodi, allowing quick access to saved films directly from the main interface
+- 🗂️ Mubi collections are automatically converted to Kodi tags, enabling easy navigation of Mubi-curated collections directly within Kodi
 
 ## Installation
 
@@ -51,6 +52,8 @@ Whenever you want to **update** the local database:
 
 ### Nov 5th, 2024
 - added the action to clean the local library after the sync. It was already implemented that movies no longer available in Mubi would be removed from the local repositry, but they would still show up in the library. Now it's fixed.
+- fixed a bug that skipped movies with special character in the title.
+- refactoring of library class, included automated testing
 
 ### October 27th 2024
 - added support to Mubi watchlist, thanks [GTBoon72](https://github.com/GTBoon72)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Whenever you want to **update** the local database:
 
 ## Changelog
 
+### Nov 5th, 2024
+- added the action to clean the local library after the sync. It was already implemented that movies no longer available in Mubi would be removed from the local repositry, but they would still show up in the library. Now it's fixed.
+
 ### October 27th 2024
 - added support to Mubi watchlist, thanks [GTBoon72](https://github.com/GTBoon72)
 

--- a/resources/lib/film.py
+++ b/resources/lib/film.py
@@ -27,6 +27,15 @@ class Film:
         self.categories = [category]  # Store categories as a list to handle multiple categories
         self.metadata = metadata
 
+    def __eq__(self, other):
+        if not isinstance(other, Film):
+            return False
+        return self.mubi_id == other.mubi_id
+
+    def __hash__(self):
+        return hash(self.mubi_id)
+
+
     def add_category(self, category: str):
         """Add a category to the film, ensuring no duplicates."""
         if category and category not in self.categories:

--- a/resources/lib/library.py
+++ b/resources/lib/library.py
@@ -8,273 +8,177 @@ import shutil
 from typing import Set
 import re
 
-
 class Library:
-    """
-    A class to manage a collection of Film objects and handle operations like merging duplicates
-    and syncing films locally.
-    """
-
     def __init__(self):
         self.films: List[Film] = []
 
     def add_film(self, film: Film):
-        """
-        Add a film to the library.
-
-        :param film: The Film object to be added.
-        :raises ValueError: If the film is invalid (missing title, ID, or metadata).
-        """
         if not film or not film.mubi_id or not film.title or not film.metadata:
             raise ValueError("Invalid film: missing required fields (mubi_id, title, or metadata).")
-        self.films.append(film)
+        if film not in self.films:
+            self.films.append(film)
 
-
-    def merge_duplicates(self, plugin_userdata_path: Path) -> List[Film]:
-        """
-        Merge duplicate films based on their Mubi ID, combining categories.
-        Removes old folders for duplicates with outdated names.
-
-        :param plugin_userdata_path: The path where the library files are saved.
-        :return: A list of unique films with merged categories.
-        """
-        # Track unique films by Mubi ID and corresponding folders
-        unique_films = {}
-        folders_by_id = {}
-
-        # Log the start of the scanning process
-        xbmc.log("Starting to scan plugin_userdata_path for existing folders.", xbmc.LOGDEBUG)
-
-        # Scan plugin_userdata_path to map existing Mubi IDs to all related folder paths
-        for folder in plugin_userdata_path.iterdir():
-            if folder.is_dir():
-                xbmc.log(f"Found directory: {folder}", xbmc.LOGDEBUG)
-
-                # Search for a STRM file in the folder, ignoring folder naming conventions
-                strm_files = list(folder.glob("*.strm"))
-                if strm_files:
-                    strm_file = strm_files[0]  # Take the first STRM file found
-                    xbmc.log(f"Found STRM file in folder '{folder}': {strm_file}", xbmc.LOGDEBUG)
-                    try:
-                        with strm_file.open("r") as f:
-                            strm_content = f.read()
-                            mubi_id = self._extract_mubi_id_from_strm(strm_content)
-                            if mubi_id:
-                                xbmc.log(f"Extracted Mubi ID '{mubi_id}' from STRM file '{strm_file}'", xbmc.LOGDEBUG)
-                                if mubi_id not in folders_by_id:
-                                    folders_by_id[mubi_id] = []
-                                folders_by_id[mubi_id].append(folder)
-                            else:
-                                xbmc.log(f"No valid Mubi ID found in STRM file '{strm_file}'", xbmc.LOGWARNING)
-                    except Exception as e:
-                        xbmc.log(f"Error reading STRM file '{strm_file}': {e}", xbmc.LOGERROR)
-                else:
-                    xbmc.log(f"No STRM file found in directory '{folder}'", xbmc.LOGDEBUG)
-
-        # Process films to merge duplicates and remove outdated folders
-        for film in self.films:
-            mubi_id = film.mubi_id
-            try:
-                if mubi_id in unique_films:
-                    # Merge categories if duplicate
-                    for category in film.categories:
-                        unique_films[mubi_id].add_category(category)
-                else:
-                    # Add the film if it's not already in the unique collection
-                    unique_films[mubi_id] = film
-            except AttributeError as e:
-                xbmc.log(f"Error processing film '{film.title}': {e}", xbmc.LOGERROR)
-
-        # Remove outdated folders for merged duplicates
-        for mubi_id, folders in folders_by_id.items():
-            # Only keep the latest folder associated with this Mubi ID
-            if mubi_id in unique_films:
-                latest_folder = folders[-1]  # Assuming last folder in list is the latest
-                expected_folder_name = unique_films[mubi_id].get_sanitized_folder_name()  # Get the sanitized name
-
-                for folder in folders:
-                    if folder.name == expected_folder_name:
-                        xbmc.log(f"Folder '{folder}' matches the expected name, skipping removal.", xbmc.LOGDEBUG)
-                        continue  # Skip if the folder name matches the expected sanitized name
-                    elif folder != latest_folder and folder.exists():
-                        try:
-                            shutil.rmtree(folder)
-                            xbmc.log(f"Removed outdated folder: {folder}", xbmc.LOGDEBUG)
-                        except Exception as e:
-                            xbmc.log(f"Error removing folder '{folder}': {e}", xbmc.LOGERROR)
-
-        # Replace the current list of films with the merged list
-        self.films = list(unique_films.values())
-        return self.films
-
-
-    def _extract_mubi_id_from_strm(self, strm_content: str) -> Optional[str]:
-        """
-        Extract the Mubi ID from the STRM file content.
-
-        :param strm_content: Content of the STRM file.
-        :return: The Mubi ID if found, else None.
-        """
-        # Assuming film_id appears as 'film_id=<id>' in the STRM content URL
-        match = re.search(r"film_id=(\d+)", strm_content)
-        return match.group(1) if match else None
-
-
-
-    def __len__(self) -> int:
-        """
-        Returns the number of films in the library.
-
-        :return: Number of films in the library.
-        """
+    def __len__(self):
         return len(self.films)
 
     def sync_locally(self, base_url: str, plugin_userdata_path: Path, omdb_api_key: Optional[str]):
         """
-        Sync the films locally by creating STRM and NFO files for each film.
-        Also removes local films that are no longer available on Mubi.
+        Synchronize the local library with fetched film data from MUBI.
 
-        :param base_url: Base URL to use for the STRM file links.
-        :param plugin_userdata_path: The path where the library files are saved.
-        :param omdb_api_key: The OMDb API key for fetching IMDb information.
-        :raises ValueError: If no films are available to sync.
+        :param base_url: The base URL for creating STRM files.
+        :param plugin_userdata_path: The path where film folders are stored.
+        :param omdb_api_key: The OMDb API key for fetching additional metadata.
         """
-        if not self.films:
-            raise ValueError("No films available to sync.")
-
-        # Merge duplicates before syncing
-        self.merge_duplicates(plugin_userdata_path)
-
-        # Collect existing film directories before syncing
-        existing_film_dirs = set()
-        for item in plugin_userdata_path.iterdir():
-            if item.is_dir():
-                existing_film_dirs.add(item.name)
-
-        # Create or update films
-        new_films_count, skipped_films_count, canceled = self.create_or_update_films(base_url, plugin_userdata_path, omdb_api_key)
-
-        # If the operation was canceled, display a cancellation message and exit
-        if canceled:
-            xbmcgui.Dialog().ok("MUBI", "All movies synced so far were saved locally")
-            return  # Exit the method early
-
-
-        # Collect current film directories after syncing
-        current_film_dirs = set()
-        for film in self.films:
-            clean_title = film.title.replace("/", " ")
-            year = film.metadata.year if film.metadata.year else "Unknown"
-            film_folder_name = f"{clean_title} ({year})"
-            current_film_dirs.add(film_folder_name)
-
-        # Remove obsolete films
-        obsolete_film_dirs = existing_film_dirs - current_film_dirs
-        obsolete_films_count = self.remove_obsolete_films(plugin_userdata_path, obsolete_film_dirs)
-
-        message = (
-            f"Sync completed successfully!\n"
-            f"New movies added: {new_films_count}\n"
-            f"Skipped, OMDb API limit hit (retry later or tomorrow): {skipped_films_count}\n"
-            f"Obsolete movies removed: {obsolete_films_count}"
-        )
-        xbmcgui.Dialog().ok("MUBI", message)
-
-    def create_or_update_films(self, base_url: str, plugin_userdata_path: Path, omdb_api_key: Optional[str]) -> Tuple[List[Film], List[Film]]:
-        """
-        Create or update STRM and NFO files for each film.
-
-        :param base_url: Base URL to use for the STRM file links.
-        :param plugin_userdata_path: The path where the library files are saved.
-        :param omdb_api_key: The OMDb API key for fetching IMDb information.
-        :return: A tuple containing two lists: (newly added films, films skipped due to OMDb request limits).
-        """
+        # Initialize counters
+        newly_added = 0
+        failed_to_add = 0
         total_films = len(self.films)
-        new_films = []  # List to store newly added films
-        skipped_films = []  # List to store films skipped due to repeated 401 errors
-        canceled = False    # Flag to indicate if the operation was canceled
 
-
+        # Initialize progress dialog
         pDialog = xbmcgui.DialogProgress()
         pDialog.create("Syncing with MUBI", "Starting the sync...")
 
-        for idx, film in enumerate(self.films):
-            percent = int((idx / total_films) * 100)
-            pDialog.update(percent, f"Processing movie {idx + 1} of {total_films}:\n{film.title}")
+        try:
+            # Process each film and update progress
+            for idx, film in enumerate(self.films):
+                percent = int(((idx + 1) / total_films) * 100)  # Ensuring 100% on last film
+                pDialog.update(percent, f"Processing movie {idx + 1} of {total_films}:\n{film.title}")
+                
+                # Check if user canceled
+                if pDialog.iscanceled():
+                    xbmc.log("User canceled the sync process.", xbmc.LOGDEBUG)
+                    break
 
-            if pDialog.iscanceled():
-                pDialog.close()
-                xbmc.log("User canceled the sync process.", xbmc.LOGDEBUG)
-                canceled = True
-                break  # Exit the loop early
+                # Process film if valid
+                if self.is_film_valid(film):
+                    result = self.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+                    if result is True:
+                        newly_added += 1
+                    elif result is False:
+                        failed_to_add += 1
+                    # If result is None, the film was skipped because files already exist
 
+            # Final cleanup of obsolete files
+            obsolete_films_count = self.remove_obsolete_files(plugin_userdata_path)
 
-            if pDialog.iscanceled():
-                pDialog.close()
-                xbmc.log("User canceled the sync process.", xbmc.LOGDEBUG)
-                return new_films, skipped_films  # Return the lists of new and skipped films
-
-            try:
-                # Prepare file name and path
-                film_folder_name = film.get_sanitized_folder_name()
-                film_path = plugin_userdata_path / film_folder_name
-
-                strm_file = film_path / f"{film_folder_name}.strm"
-                nfo_file = film_path / f"{film_folder_name}.nfo"
-
-                # Check if the film directory and both files already exist
-                if film_path.exists() and strm_file.exists() and nfo_file.exists():
-                    xbmc.log(f"Film '{film.title}' already synced. Skipping...", xbmc.LOGDEBUG)
-                    continue  # Skip to the next film
-
-                # Create the folder if it doesn't exist
-                film_path.mkdir(parents=True, exist_ok=True)
-
-                # First, attempt to create the NFO file
-                film.create_nfo_file(film_path, base_url, omdb_api_key)
-
-                # Check if NFO creation was skipped (due to repeated 401 errors or other issues)
-                if not nfo_file.exists():
-                    xbmc.log(f"Skipping creation of STRM file for '{film.title}' as NFO file was not created.", xbmc.LOGWARNING)
-                    skipped_films.append(film)  # Add to skipped films list
-                    continue  # Skip to the next film
-
-                # Create the STRM file only if NFO was successfully created
-                film.create_strm_file(film_path, base_url)
-
-                # Add to the list of new films
-                new_films.append(film)
-
-            except OSError as error:
-                xbmc.log(f"Error while creating library files for film '{film.title}': {error}", xbmc.LOGERROR)
-            except ValueError as error:
-                xbmc.log(f"Invalid data for film '{film.title}': {error}", xbmc.LOGERROR)
-
-        pDialog.close()
-
-        # Return a tuple of newly added films and films skipped due to 401 errors
-        return len(new_films), len(skipped_films), canceled
+            # Construct summary message
+            message = (
+                f"Sync completed successfully!\n"
+                f"New movies added: {newly_added}\n"
+                f"Failed to add: {failed_to_add}\n"
+                f"Obsolete movies removed: {obsolete_films_count}"
+            )
+            
+            # Log results
+            xbmc.log(
+                f"Sync completed. New films: {newly_added}, Failed films: {failed_to_add}, "
+                f"Obsolete films removed: {obsolete_films_count}",
+                xbmc.LOGDEBUG
+            )
+            
+            # Show summary dialog
+            xbmcgui.Dialog().ok("MUBI", message)
+        finally:
+            # Ensure the dialog is closed in the end
+            pDialog.close()
 
 
 
+    def is_film_valid(self, film: Film) -> bool:
+        # Check that film has all necessary attributes
+        return film.mubi_id and film.title and film.metadata
 
-    def remove_obsolete_films(self, plugin_userdata_path: Path, obsolete_film_dirs: Set[str]) -> int:
+    def prepare_files_for_film(
+        self, film: Film, base_url: str, plugin_userdata_path: Path, omdb_api_key: Optional[str]
+    ) -> Optional[bool]:
         """
-        Remove local film directories that are no longer available on Mubi.
+        Prepare the necessary files for a given film. Creates NFO and STRM files.
+        The STRM file is only created if the NFO file is successfully created.
+        If the NFO file creation fails, the STRM file is not created, and the movie folder is removed.
 
-        :param plugin_userdata_path: The path where the library files are saved.
-        :param obsolete_film_dirs: A set of directory names corresponding to obsolete films.
-        :return: The number of obsolete films removed.
+        :param film: The Film object to process.
+        :param base_url: The base URL for the STRM file.
+        :param plugin_userdata_path: The path where film folders are stored.
+        :param omdb_api_key: The OMDb API key for fetching additional metadata.
+        :return: 
+            - True if both NFO and STRM files were created successfully.
+            - False if file creation failed.
+            - None if files already exist and were skipped.
         """
-        obsolete_films_count = 0
-        for dir_name in obsolete_film_dirs:
-            dir_path = plugin_userdata_path / dir_name
-            try:
-                # Remove the directory and its contents
-                shutil.rmtree(dir_path)
-                obsolete_films_count += 1
-                xbmc.log(f"Removed obsolete film directory: {dir_path}", xbmc.LOGDEBUG)
-            except Exception as e:
-                xbmc.log(f"Error removing obsolete film directory '{dir_path}': {e}", xbmc.LOGERROR)
-        return obsolete_films_count
+        film_folder_name = film.get_sanitized_folder_name()
+        film_path = plugin_userdata_path / film_folder_name
+
+        # Define file paths
+        strm_file = film_path / f"{film_folder_name}.strm"
+        nfo_file = film_path / f"{film_folder_name}.nfo"
+
+        try:
+            # Check if both STRM and NFO files already exist
+            if strm_file.exists() and nfo_file.exists():
+                xbmc.log(f"Skipping film '{film.title}' - files already exist.", xbmc.LOGDEBUG)
+                return None  # Files already exist; no action needed
+        except PermissionError as e:
+            xbmc.log(f"PermissionError when accessing files for film '{film.title}': {e}", xbmc.LOGERROR)
+            return False  # Indicate failure due to permission error
+
+        try:
+            # Create the movie folder if it doesn't exist
+            film_path.mkdir(parents=True, exist_ok=True)
+            xbmc.log(f"Created folder '{film_path}'.", xbmc.LOGDEBUG)
+
+            # Attempt to create the NFO file first
+            xbmc.log(f"Creating NFO file for film '{film.title}'.", xbmc.LOGDEBUG)
+            film.create_nfo_file(film_path, base_url, omdb_api_key)
+
+            # Verify if the NFO file was created successfully
+            if not nfo_file.exists():
+                xbmc.log(
+                    f"Skipping creation of STRM file for '{film.title}' as NFO file was not created.",
+                    xbmc.LOGWARNING
+                )
+                # Remove the movie folder since NFO creation failed
+                shutil.rmtree(film_path)
+                xbmc.log(f"Removed folder '{film_path}' due to failed NFO creation.", xbmc.LOGDEBUG)
+                return False  # Indicate failure in file creation
+
+            # If NFO was created successfully, proceed to create the STRM file
+            xbmc.log(f"Creating STRM file for film '{film.title}'.", xbmc.LOGDEBUG)
+            film.create_strm_file(film_path, base_url)
+            xbmc.log(f"Successfully created STRM file for '{film.title}'.", xbmc.LOGDEBUG)
+
+            return True  # Indicate successful creation of both files
+
+        except Exception as e:
+            # Handle unexpected exceptions during file operations
+            xbmc.log(f"Error processing film '{film.title}': {e}", xbmc.LOGERROR)
+            # Attempt to remove the folder if it exists to maintain consistency
+            if film_path.exists():
+                shutil.rmtree(film_path)
+                xbmc.log(f"Removed folder '{film_path}' due to error.", xbmc.LOGDEBUG)
+            return False  # Indicate failure due to exception
+
+
+
+
+    def remove_obsolete_files(self, plugin_userdata_path: Path) -> int:
+        """
+        Remove folders in plugin_userdata_path that do not correspond to any film in the library.
+        
+        :param plugin_userdata_path: Path where the film folders are stored.
+        :return: The number of obsolete film folders removed.
+        """
+        # Get a set of sanitized folder names for the current films in the library
+        current_film_folders = {film.get_sanitized_folder_name() for film in self.films}
+
+        # Track obsolete folder count
+        obsolete_folders_count = 0
+
+        # Loop through each directory in plugin_userdata_path
+        for folder in plugin_userdata_path.iterdir():
+            if folder.is_dir() and folder.name not in current_film_folders:
+                # Remove the folder if it's not in the current films
+                shutil.rmtree(folder)
+                obsolete_folders_count += 1
+
+        return obsolete_folders_count
 

--- a/resources/lib/navigation_handler.py
+++ b/resources/lib/navigation_handler.py
@@ -400,8 +400,9 @@ class NavigationHandler:
             pDialog.close()
             xbmcgui.Dialog().notification("MUBI", "Sync completed successfully!", xbmcgui.NOTIFICATION_INFO)
 
-            # Trigger Kodi library update after sync is done
+            # Trigger Kodi library update and clean after sync is done
             self.update_kodi_library()
+            self.clean_kodi_library()
 
         except Exception as e:
             xbmc.log(f"Error during sync: {e}", xbmc.LOGERROR)
@@ -417,3 +418,14 @@ class NavigationHandler:
             xbmcgui.Dialog().notification("MUBI", "Kodi library update triggered.", xbmcgui.NOTIFICATION_INFO)
         except Exception as e:
             xbmc.log(f"Error triggering Kodi library update: {e}", xbmc.LOGERROR)
+
+    def clean_kodi_library(self):
+        """
+        Triggers a Kodi library clean to remove items from the library that are not found locally.
+        """
+        try:
+            xbmc.log("Triggering Kodi library clean...", xbmc.LOGDEBUG)
+            xbmc.executebuiltin('CleanLibrary(video)')
+            xbmcgui.Dialog().notification("MUBI", "Kodi library clean triggered.", xbmcgui.NOTIFICATION_INFO)
+        except Exception as e:
+            xbmc.log(f"Error triggering Kodi library clean: {e}", xbmc.LOGERROR)

--- a/resources/lib/navigation_handler.py
+++ b/resources/lib/navigation_handler.py
@@ -78,14 +78,17 @@ class NavigationHandler:
             ]
 
     def _add_menu_item(self, item: dict):
-        """ Helper method to add a menu item to Kodi """
         try:
             list_item = xbmcgui.ListItem(label=item["label"])
-            list_item.setInfo("video", {"title": item["label"], "plot": item["description"], "mediatype": "video"})
+            info_tag = list_item.getVideoInfoTag()
+            info_tag.setTitle(item["label"])
+            info_tag.setPlot(item["description"])
+            info_tag.setMediaType("video")
             url = self.get_url(action=item["action"])
             xbmcplugin.addDirectoryItem(self.handle, url, list_item, item["is_folder"])
         except Exception as e:
             xbmc.log(f"Error adding menu item {item['label']}: {e}", xbmc.LOGERROR)
+
 
     def list_categories(self):
         """
@@ -107,15 +110,23 @@ class NavigationHandler:
             xbmc.log(f"Error listing categories: {e}", xbmc.LOGERROR)
 
     def _add_category_item(self, category: dict):
-        """ Helper method to add a category to the Kodi directory """
         try:
             list_item = xbmcgui.ListItem(label=category["title"])
-            list_item.setInfo("video", {"title": category["title"], "plot": category["description"], "mediatype": "video"})
-            list_item.setArt({"thumb": category["image"], "poster": category["image"], "banner": category["image"], "fanart": category["image"]})
+            info_tag = list_item.getVideoInfoTag()
+            info_tag.setTitle(category["title"])
+            info_tag.setPlot(category["description"])
+            info_tag.setMediaType("video")
+            list_item.setArt({
+                "thumb": category["image"],
+                "poster": category["image"],
+                "banner": category["image"],
+                "fanart": category["image"]
+            })
             url = self.get_url(action="listing", id=category["id"], category_name=category["title"])
             xbmcplugin.addDirectoryItem(self.handle, url, list_item, True)
         except Exception as e:
             xbmc.log(f"Error adding category item {category['title']}: {e}", xbmc.LOGERROR)
+
 
     def list_watchlist(self):
         """
@@ -158,34 +169,78 @@ class NavigationHandler:
             xbmc.log(f"Error listing videos: {e}", xbmc.LOGERROR)
 
     def _add_film_item(self, film):
-        """ Helper method to add a film item to the Kodi directory """
         try:
             list_item = xbmcgui.ListItem(label=film.title)
-            list_item.setInfo("video", {
-                "title": film.title,
-                "originaltitle": film.metadata.originaltitle,
-                "genre": ', '.join(film.metadata.genre),
-                "plot": film.metadata.plot,
-                "mediatype": "video"
-            })
-            list_item.setArt({
-                "thumb": film.metadata.image,
-                "poster": film.metadata.image,
-                "fanart": film.metadata.image,
-                "landscape": film.metadata.image
-            })
-            
+            info_tag = list_item.getVideoInfoTag()
+
+            # Set basic metadata
+            info_tag.setTitle(film.title)
+
+            if hasattr(film.metadata, 'originaltitle') and film.metadata.originaltitle:
+                info_tag.setOriginalTitle(film.metadata.originaltitle)
+
+            if hasattr(film.metadata, 'genre') and film.metadata.genre:
+                genres = film.metadata.genre
+                if isinstance(genres, str):
+                    genres = [genres]
+                info_tag.setGenres(genres)  # Expects a list
+
+            if hasattr(film.metadata, 'plot') and film.metadata.plot:
+                info_tag.setPlot(film.metadata.plot)
+
+            if hasattr(film.metadata, 'year') and film.metadata.year:
+                info_tag.setYear(int(film.metadata.year))
+
+            if hasattr(film.metadata, 'duration') and film.metadata.duration:
+                info_tag.setDuration(int(film.metadata.duration))  # Duration in seconds
+
+            if hasattr(film.metadata, 'director') and film.metadata.director:
+                directors = film.metadata.director
+                if isinstance(directors, str):
+                    directors = [directors]
+                 .setDirectors(directors)  # Expects a list
+
+            if hasattr(film.metadata, 'cast') and film.metadata.cast:
+                info_tag.setCast(film.metadata.cast)  # Expects a list of dicts with 'name' keys
+
+            if hasattr(film.metadata, 'rating') and film.metadata.rating:
+                info_tag.setRating(float(film.metadata.rating))
+
+            if hasattr(film.metadata, 'votes') and film.metadata.votes:
+                info_tag.setVotes(int(film.metadata.votes))
+
+            if hasattr(film.metadata, 'imdb_id') and film.metadata.imdb_id:
+                info_tag.setUniqueID(film.metadata.imdb_id, 'imdb')
+
+            info_tag.setMediaType('movie')
+
+            # Set artwork
+            if hasattr(film.metadata, 'image') and film.metadata.image:
+                list_item.setArt({
+                    "thumb": film.metadata.image,
+                    "poster": film.metadata.image,
+                    "fanart": film.metadata.image,
+                    "landscape": film.metadata.image
+                })
+
             # Set 'IsPlayable' property to inform Kodi this is a playable item
             list_item.setProperty('IsPlayable', 'true')
-            
+
             # Set the URL and path to the plugin URL
             url = self.get_url(action="play_mubi_video", film_id=film.mubi_id)
             list_item.setPath(url)
-            
+
             # Add the item to the directory with isFolder=False
             xbmcplugin.addDirectoryItem(self.handle, url, list_item, isFolder=False)
+
         except Exception as e:
             xbmc.log(f"Error adding film item {film.title}: {e}", xbmc.LOGERROR)
+            import traceback
+            xbmc.log(traceback.format_exc(), xbmc.LOGERROR)
+
+
+
+
 
 
     def play_video_ext(self, web_url: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock xbmc and other related modules
+sys.modules['xbmc'] = MagicMock()
+sys.modules['xbmcgui'] = MagicMock()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,552 @@
+import tempfile
+from unittest.mock import patch, call
+from pathlib import Path
+from resources.lib.film import Film
+from resources.lib.library import Library
+import pytest
+import os
+
+# Mock Metadata class for testing
+class MockMetadata:
+    def __init__(self, year):
+        self.year = year
+
+def test_add_valid_film():
+    library = Library()
+    metadata = MockMetadata(year=2023)
+    film = Film(mubi_id="123456", title="Sample Movie", artwork="http://example.com/art.jpg", web_url="http://example.com", category="Drama", metadata=metadata)
+    library.add_film(film)
+    assert len(library.films) == 1, "Film should have been added to the library."
+
+def test_library_len():
+    library = Library()
+    assert len(library) == 0, "Expected library length to be 0 when empty."
+    film1 = Film(mubi_id="123", title="Film One", artwork="http://example.com/art1.jpg", web_url="http://example.com/film1", category="Drama", metadata=MockMetadata(2021))
+    film2 = Film(mubi_id="456", title="Film Two", artwork="http://example.com/art2.jpg", web_url="http://example.com/film2", category="Comedy", metadata=MockMetadata(2022))
+    library.add_film(film1)
+    library.add_film(film2)
+    assert len(library) == 2, "Expected library length to be 2 after adding two films."
+
+@patch.object(Film, "create_nfo_file")
+@patch.object(Film, "create_strm_file")
+def test_prepare_files_for_film_success(mock_create_strm, mock_create_nfo):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+        
+        # Create a Film object
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="123456",
+            title="Sample Movie",
+            artwork="http://example.com/art.jpg",
+            web_url="http://example.com",
+            category="Drama",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        # Prepare paths
+        film_folder_name = film.get_sanitized_folder_name()
+        film_path = plugin_userdata_path / film_folder_name
+        nfo_file = film_path / f"{film_folder_name}.nfo"
+        strm_file = film_path / f"{film_folder_name}.strm"
+
+        # Mock create_nfo_file to create the NFO file
+        def create_nfo_side_effect(film_path_arg, base_url_arg, omdb_api_key_arg):
+            film_path_arg.mkdir(parents=True, exist_ok=True)
+            nfo_file.touch()
+
+        mock_create_nfo.side_effect = create_nfo_side_effect
+
+        # Mock create_strm_file to create the STRM file
+        def create_strm_side_effect(film_path_arg, base_url_arg):
+            strm_file.touch()
+
+        mock_create_strm.side_effect = create_strm_side_effect
+
+        # Run prepare_files_for_film
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film returned True
+        assert result is True, "prepare_files_for_film should return True for successful file creation."
+
+        # Check if the calls to `create_nfo_file` and `create_strm_file` have the expected arguments
+        expected_folder = plugin_userdata_path / film.get_sanitized_folder_name()
+        
+        # Assert that create_nfo_file is called with `expected_folder`, `base_url`, and `omdb_api_key`
+        mock_create_nfo.assert_called_once_with(expected_folder, base_url, omdb_api_key)
+        
+        # Assert that create_strm_file is called with `expected_folder` and `base_url`
+        mock_create_strm.assert_called_once_with(expected_folder, base_url)
+
+
+@patch.object(Film, "create_nfo_file")
+@patch.object(Film, "create_strm_file")
+def test_prepare_files_for_film_skipped(mock_create_strm, mock_create_nfo):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+        
+        # Create a Film object
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="789012",
+            title="Existing Movie",
+            artwork="http://example.com/art2.jpg",
+            web_url="http://example.com",
+            category="Comedy",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        # Prepare paths
+        film_folder_name = film.get_sanitized_folder_name()
+        film_path = plugin_userdata_path / film_folder_name
+        nfo_file = film_path / f"{film_folder_name}.nfo"
+        strm_file = film_path / f"{film_folder_name}.strm"
+
+        # Simulate existing files by creating them
+        film_path.mkdir(parents=True, exist_ok=True)
+        nfo_file.touch()
+        strm_file.touch()
+
+        # Run prepare_files_for_film
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film returned None
+        assert result is None, "prepare_files_for_film should return None when files already exist."
+
+        # Assert that create_nfo_file and create_strm_file were not called
+        mock_create_nfo.assert_not_called()
+        mock_create_strm.assert_not_called()
+
+
+@patch.object(Film, "create_nfo_file")
+@patch.object(Film, "create_strm_file")
+def test_prepare_files_for_film_failure(mock_create_strm, mock_create_nfo):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+        
+        # Create a Film object
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="345678",
+            title="Failed Movie",
+            artwork="http://example.com/art3.jpg",
+            web_url="http://example.com",
+            category="Action",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        # Prepare paths
+        film_folder_name = film.get_sanitized_folder_name()
+        film_path = plugin_userdata_path / film_folder_name
+        nfo_file = film_path / f"{film_folder_name}.nfo"
+        strm_file = film_path / f"{film_folder_name}.strm"
+
+        # Mock create_nfo_file to simulate failure (do nothing)
+        def create_nfo_side_effect(film_path_arg, base_url_arg, omdb_api_key_arg):
+            pass  # Do nothing; NFO file is not created
+
+        mock_create_nfo.side_effect = create_nfo_side_effect
+
+        # Run prepare_files_for_film
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+
+        # Ensure that the NFO file does not exist
+        assert not nfo_file.exists()
+
+        result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film returned False
+        assert result is False, "prepare_files_for_film should return False when file creation fails."
+
+        # Assert that create_nfo_file was called
+        expected_folder = plugin_userdata_path / film.get_sanitized_folder_name()
+        mock_create_nfo.assert_called_once_with(expected_folder, base_url, omdb_api_key)
+
+        # Assert that create_strm_file was not called since NFO creation failed
+        mock_create_strm.assert_not_called()
+
+def test_remove_obsolete_files():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+
+        # Create dummy folders to simulate obsolete files
+        (plugin_userdata_path / "Old Film (2021)").mkdir()
+        (plugin_userdata_path / "Another Old Film (2022)").mkdir()
+
+        # Create a film and add it to the library
+        library = Library()
+        metadata = MockMetadata(year=2023)
+        film = Film(mubi_id="123456", title="Current Film", artwork="http://example.com/art.jpg", web_url="http://example.com", category="Drama", metadata=metadata)
+        library.add_film(film)
+
+        # Create the folder for the current film to simulate an existing folder
+        current_folder = plugin_userdata_path / film.get_sanitized_folder_name()
+        current_folder.mkdir()
+
+        # Remove obsolete files
+        library.remove_obsolete_files(plugin_userdata_path)
+
+        # Check that obsolete folders were removed
+        assert not (plugin_userdata_path / "Old Film (2021)").exists(), "Obsolete folder 'Old Film (2021)' was not removed."
+        assert not (plugin_userdata_path / "Another Old Film (2022)").exists(), "Obsolete folder 'Another Old Film (2022)' was not removed."
+
+        # Check that the current film folder was not removed
+        assert current_folder.exists(), "Current film folder should not have been removed."
+
+@patch("xbmcgui.DialogProgress")
+@patch.object(Library, "prepare_files_for_film")
+@patch.object(Library, "remove_obsolete_files")
+def test_sync_locally(mock_remove_obsolete, mock_prepare_files, mock_dialog_progress):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+
+        # Create Film objects and add them to the library
+        metadata = MockMetadata(year=2023)
+        film1 = Film(mubi_id="123", title="Sample Movie 1", artwork="http://example.com/art1.jpg",
+                     web_url="http://example.com/film1", category="Drama", metadata=metadata)
+        film2 = Film(mubi_id="456", title="Sample Movie 2", artwork="http://example.com/art2.jpg",
+                     web_url="http://example.com/film2", category="Comedy", metadata=metadata)
+        library.add_film(film1)
+        library.add_film(film2)
+
+        # Set up mock behavior for prepare_files_for_film
+        mock_prepare_files.side_effect = [
+            ([film1], []),  # Return new films for film1
+            ([], [film2])   # Return skipped for film2
+        ]
+
+        # Mock dialog behavior to not cancel
+        mock_dialog = mock_dialog_progress.return_value
+        mock_dialog.iscanceled.return_value = False
+
+        # Run sync_locally
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        library.sync_locally(base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assertions for progress dialog
+        mock_dialog.create.assert_called_once_with("Syncing with MUBI", "Starting the sync...")
+        assert mock_dialog.update.call_count == 2, "Progress dialog should have been updated twice"
+        mock_dialog.close.assert_called_once()
+
+        # Assert that prepare_files_for_film was called for each film
+        expected_calls = [
+            call(film1, base_url, plugin_userdata_path, omdb_api_key),
+            call(film2, base_url, plugin_userdata_path, omdb_api_key)
+        ]
+        mock_prepare_files.assert_has_calls(expected_calls, any_order=False)
+
+        # Assert that remove_obsolete_files was called
+        mock_remove_obsolete.assert_called_once_with(plugin_userdata_path)
+
+@patch("xbmcgui.DialogProgress")
+@patch.object(Library, "prepare_files_for_film")
+@patch.object(Library, "remove_obsolete_files")
+def test_sync_locally_user_cancellation(mock_remove_obsolete, mock_prepare_files, mock_dialog_progress):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+
+        # Create Film objects and add them to the library
+        metadata = MockMetadata(year=2023)
+        film1 = Film(mubi_id="123", title="Sample Movie 1", artwork="http://example.com/art1.jpg",
+                     web_url="http://example.com/film1", category="Drama", metadata=metadata)
+        film2 = Film(mubi_id="456", title="Sample Movie 2", artwork="http://example.com/art2.jpg",
+                     web_url="http://example.com/film2", category="Comedy", metadata=metadata)
+        library.add_film(film1)
+        library.add_film(film2)
+
+        # Set up mock behavior for prepare_files_for_film
+        mock_prepare_files.return_value = True
+
+        # Mock dialog behavior to simulate cancellation after first film
+        mock_dialog = mock_dialog_progress.return_value
+        mock_dialog.iscanceled.side_effect = [False, True]  # Cancel after first update
+
+        # Run sync_locally
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        library.sync_locally(base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film was called only once
+        mock_prepare_files.assert_called_once_with(film1, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that remove_obsolete_files was called
+        mock_remove_obsolete.assert_called_once_with(plugin_userdata_path)
+@patch.object(Film, "create_nfo_file")
+@patch.object(Film, "create_strm_file")
+def test_prepare_files_for_film_exception_in_nfo(mock_create_strm, mock_create_nfo):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+
+        # Create a Film object
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="999999",
+            title="Exception Movie",
+            artwork="http://example.com/art.jpg",
+            web_url="http://example.com",
+            category="Drama",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        # Simulate exception in create_nfo_file
+        mock_create_nfo.side_effect = Exception("Simulated exception in create_nfo_file")
+
+        # Run prepare_files_for_film
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film returned False
+        assert result is False, "Should return False when an exception occurs in create_nfo_file."
+
+        # Assert that create_strm_file was not called
+        mock_create_strm.assert_not_called()
+
+@patch.object(Film, "create_nfo_file")
+@patch.object(Film, "create_strm_file")
+def test_prepare_files_for_film_exception_in_strm(mock_create_strm, mock_create_nfo):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+
+        # Create a Film object
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="888888",
+            title="Exception Movie",
+            artwork="http://example.com/art.jpg",
+            web_url="http://example.com",
+            category="Drama",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        # Mock create_nfo_file to create the NFO file
+        def create_nfo_side_effect(film_path_arg, base_url_arg, omdb_api_key_arg):
+            film_path_arg.mkdir(parents=True, exist_ok=True)
+            (film_path_arg / f"{film.get_sanitized_folder_name()}.nfo").touch()
+
+        mock_create_nfo.side_effect = create_nfo_side_effect
+
+        # Simulate exception in create_strm_file
+        mock_create_strm.side_effect = Exception("Simulated exception in create_strm_file")
+
+        # Run prepare_files_for_film
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film returned False
+        assert result is False, "Should return False when an exception occurs in create_strm_file."
+
+def test_remove_obsolete_files_no_obsolete():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+
+        # Create a film and add it to the library
+        library = Library()
+        metadata = MockMetadata(year=2023)
+        film = Film(mubi_id="123456", title="Current Film", artwork="http://example.com/art.jpg",
+                    web_url="http://example.com", category="Drama", metadata=metadata)
+        library.add_film(film)
+
+        # Create the folder for the current film to simulate an existing folder
+        current_folder = plugin_userdata_path / film.get_sanitized_folder_name()
+        current_folder.mkdir()
+
+        # Remove obsolete files
+        count = library.remove_obsolete_files(plugin_userdata_path)
+
+        # Assert that no folders were removed
+        assert count == 0, "No obsolete folders should have been removed."
+        assert current_folder.exists(), "Current film folder should not have been removed."
+def test_remove_obsolete_files_nonexistent_path():
+    plugin_userdata_path = Path("/non/existent/path")
+
+    # Create a film and add it to the library
+    library = Library()
+    metadata = MockMetadata(year=2023)
+    film = Film(mubi_id="123456", title="Current Film", artwork="http://example.com/art.jpg",
+                web_url="http://example.com", category="Drama", metadata=metadata)
+    library.add_film(film)
+
+    # Attempt to remove obsolete files
+    try:
+        count = library.remove_obsolete_files(plugin_userdata_path)
+        assert count == 0, "Should return 0 when path does not exist."
+    except FileNotFoundError:
+        # Expected behavior if the method does not handle non-existent paths internally
+        pass
+
+@patch("xbmcgui.DialogProgress")
+@patch.object(Library, "remove_obsolete_files")
+def test_sync_locally_empty_library(mock_remove_obsolete, mock_dialog_progress):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()  # Empty library
+
+        # Mock dialog behavior to not cancel
+        mock_dialog = mock_dialog_progress.return_value
+        mock_dialog.iscanceled.return_value = False
+
+        # Run sync_locally
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        library.sync_locally(base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assertions for progress dialog
+        mock_dialog.create.assert_called_once_with("Syncing with MUBI", "Starting the sync...")
+        mock_dialog.update.assert_not_called()
+        mock_dialog.close.assert_called_once()
+
+        # Assert that remove_obsolete_files was called
+        mock_remove_obsolete.assert_called_once_with(plugin_userdata_path)
+
+def test_prepare_files_for_film_with_invalid_characters():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+
+        # Create a Film object with invalid characters in the title
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="654321",
+            title="Invalid/Character: Movie*?",
+            artwork="http://example.com/art.jpg",
+            web_url="http://example.com",
+            category="Drama",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        # Run prepare_files_for_film
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+
+        # Mock create_nfo_file and create_strm_file to create files
+        with patch.object(Film, "create_nfo_file") as mock_create_nfo, \
+             patch.object(Film, "create_strm_file") as mock_create_strm:
+            def create_nfo_side_effect(film_path_arg, base_url_arg, omdb_api_key_arg):
+                film_path_arg.mkdir(parents=True, exist_ok=True)
+                (film_path_arg / f"{film.get_sanitized_folder_name()}.nfo").touch()
+
+            def create_strm_side_effect(film_path_arg, base_url_arg):
+                (film_path_arg / f"{film.get_sanitized_folder_name()}.strm").touch()
+
+            mock_create_nfo.side_effect = create_nfo_side_effect
+            mock_create_strm.side_effect = create_strm_side_effect
+
+            result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+            # Assert that prepare_files_for_film returned True
+            assert result is True, "Should return True when files are created successfully."
+
+            # Check that the folder was created with sanitized name
+            sanitized_folder_name = film.get_sanitized_folder_name()
+            film_path = plugin_userdata_path / sanitized_folder_name
+            assert film_path.exists(), "Film folder with sanitized name should exist."
+
+
+def test_prepare_files_for_film_unwritable_path():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname) / "unwritable_dir"
+        plugin_userdata_path.mkdir()
+        os.chmod(plugin_userdata_path, 0o400)  # Read-only permissions
+
+        library = Library()
+        metadata = MockMetadata(year=2023)
+        film = Film(
+            mubi_id="777777",
+            title="Unwritable Path Movie",
+            artwork="http://example.com/art.jpg",
+            web_url="http://example.com",
+            category="Drama",
+            metadata=metadata
+        )
+        library.add_film(film)
+
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+
+        # Run prepare_files_for_film
+        result = library.prepare_files_for_film(film, base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film returned False due to exception
+        assert result is False, "Should return False when unable to write to the directory."
+
+        # Reset permissions for cleanup
+        os.chmod(plugin_userdata_path, 0o700)
+
+
+@patch("xbmcgui.DialogProgress")
+@patch.object(Library, "prepare_files_for_film")
+@patch.object(Library, "remove_obsolete_files")
+def test_sync_locally_large_library(mock_remove_obsolete, mock_prepare_files, mock_dialog_progress):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        plugin_userdata_path = Path(tmpdirname)
+        library = Library()
+
+        # Create 1000 Film objects and add them to the library
+        metadata = MockMetadata(year=2023)
+        for i in range(1000):
+            film = Film(
+                mubi_id=str(i),
+                title=f"Sample Movie {i}",
+                artwork=f"http://example.com/art{i}.jpg",
+                web_url=f"http://example.com/film{i}",
+                category="Drama",
+                metadata=metadata
+            )
+            library.add_film(film)
+
+        # Set up mock behavior for prepare_files_for_film
+        mock_prepare_files.return_value = True
+
+        # Mock dialog behavior to not cancel
+        mock_dialog = mock_dialog_progress.return_value
+        mock_dialog.iscanceled.return_value = False
+
+        # Run sync_locally
+        base_url = "plugin://plugin.video.mubi/"
+        omdb_api_key = "fake_api_key"
+        library.sync_locally(base_url, plugin_userdata_path, omdb_api_key)
+
+        # Assert that prepare_files_for_film was called 1000 times
+        assert mock_prepare_files.call_count == 1000, "prepare_files_for_film should be called 1000 times."
+
+def test_add_duplicate_film():
+    library = Library()
+    metadata = MockMetadata(year=2023)
+    film = Film(mubi_id="123456", title="Sample Movie", artwork="http://example.com/art.jpg",
+                web_url="http://example.com", category="Drama", metadata=metadata)
+    library.add_film(film)
+    library.add_film(film)
+    assert len(library) == 1, "Library should contain only one instance of the film."
+
+def test_film_equality():
+    metadata = MockMetadata(year=2023)
+    film1 = Film(mubi_id="123456", title="Sample Movie", artwork="http://example.com/art.jpg",
+                 web_url="http://example.com", category="Drama", metadata=metadata)
+    film2 = Film(mubi_id="123456", title="Sample Movie", artwork="http://example.com/art.jpg",
+                 web_url="http://example.com", category="Drama", metadata=metadata)
+    film3 = Film(mubi_id="654321", title="Another Movie", artwork="http://example.com/art2.jpg",
+                 web_url="http://example.com", category="Drama", metadata=metadata)
+
+    assert film1 == film2, "Films with the same mubi_id should be equal."
+    assert film1 != film3, "Films with different mubi_id should not be equal."


### PR DESCRIPTION
- trigger the kodi library clean after sync (will remove from the library the entries where there is no file locally)
- fixed a bug where movies with special characters where not created locally
- refactored the library class and added tests