### PR TITLE
Skip genres

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The goal of this addon is to harness Kodi's excellent browsing and metadata scra
 - 🈯 Supports display of titles and descriptions in the languages supported by Mubi
 - 🔖 Retrieves and displays your MUBI watchlist within Kodi, allowing quick access to saved films directly from the main interface
 - 🗂️ Mubi collections are automatically converted to Kodi tags, enabling easy navigation of Mubi-curated collections directly within Kodi
+- 🎛️ Skip specific Mubi genres: Configure the addon to ignore movies from certain genres. Go to settings and enter the genres you'd like to skip, separated by semicolons (e.g., horror;comedy).
 
 ## Installation
 
@@ -54,6 +55,7 @@ Whenever you want to **update** the local database:
 - added the action to clean the local library after the sync. It was already implemented that movies no longer available in Mubi would be removed from the local repositry, but they would still show up in the library. Now it's fixed.
 - fixed a bug that skipped movies with special character in the title.
 - refactoring of library class, included automated testing
+- added the possiblity to skip Mubi genres you don't want to see in your library. Go to settings and enter the genres you'd like to skip, separated by semicolons (e.g., horror;comedy).
 
 ### October 27th 2024
 - added support to Mubi watchlist, thanks [GTBoon72](https://github.com/GTBoon72)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <category label="General">
-        <setting id="omdbapiKey" label="OMDB api Key" type="text" default=""/>
+        <setting id="omdbapiKey" label="OMDB API Key" type="text" default=""/>
         <setting id="client_country" label="Country" type="text" default="" visible="false"/>
         <setting id="deviceID" type="text" default="" visible="false"/>
         <setting id="logged" type="bool" default="false" visible="false"/>
@@ -9,5 +9,10 @@
         <setting id="userID" type="text" default="" visible="false"/>
         <setting label="Language for titles and descriptions" type="labelenum" id="accept-language" values="tr|en|fr|es|de|it|nl|pt" default=""/>
         <setting id="first_run_completed" type="bool" default="false" visible="false"/>
+    </category>
+
+    <!-- New Category for Advanced Settings -->
+    <category label="Genres to skip">
+        <setting id="skip_genres" label="Genres to skip (separate multiple genres with semicolons)" type="text" default=""/>
     </category>
 </settings>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,6 @@ from unittest.mock import MagicMock
 
 # Mock xbmc and other related modules
 sys.modules['xbmc'] = MagicMock()
+sys.modules['xbmcaddon'] = MagicMock()
 sys.modules['xbmcgui'] = MagicMock()
+sys.modules['xbmcplugin'] = MagicMock()


### PR DESCRIPTION
Configure the addon to ignore movies from certain genres. Go to settings and enter the genres you'd like to skip, separated by semicolons (e.g., horror;comedy).