### PR TITLE
Fix Mubi shallow-sync schema validation and broken login URL

### DIFF
--- a/backend/schemas/v1_schema.json
+++ b/backend/schemas/v1_schema.json
@@ -407,6 +407,12 @@
                             "null"
                         ]
                     },
+                    "early_access_film_date_message": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
                     "exclusive": {
                         "type": [
                             "boolean",

--- a/backend/scraper.py
+++ b/backend/scraper.py
@@ -547,6 +547,7 @@ class MubiScraper:
                             consumable_copy.pop('offered', None)           # Always catalogue
                             consumable_copy.pop('film_id', None)           # Already at top level
                             consumable_copy.pop('film_date_message', None) # Always null
+                            consumable_copy.pop('early_access_film_date_message', None) # Early-access banner text, not used
                             consumable_copy.pop('exclusive', None)         # Not used
                             consumable_copy.pop('permit_download', None)   # Not used
                             

--- a/repo/plugin_video_mubi/resources/lib/navigation_handler.py
+++ b/repo/plugin_video_mubi/resources/lib/navigation_handler.py
@@ -946,7 +946,7 @@ class NavigationHandler:
     def _display_login_code(self, code_info: dict):
         """ Helper method to display login code to the user """
         link_code = code_info['link_code']
-        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]https://mubi.com/android[/B]")
+        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]https://mubi.com/tv[/B]")
 
     def _handle_login_error(self, auth_response: dict):
         """ Handle login errors from the Mubi API """

--- a/tests/plugin_video_mubi/test_navigation_handler.py
+++ b/tests/plugin_video_mubi/test_navigation_handler.py
@@ -303,6 +303,20 @@ class TestNavigationHandler:
         assert call_args[1] == 'Error during code generation.'
         # Third parameter is the notification type (NOTIFICATION_ERROR)
 
+    def test_display_login_code_uses_current_activation_url(self, navigation_handler):
+        """The login dialog must point users at the current Mubi activation URL.
+
+        Mubi retired https://mubi.com/android (now a 404); the correct page is
+        https://mubi.com/tv. Guard against silently reintroducing a dead URL.
+        """
+        with patch('xbmcgui.Dialog') as mock_dialog:
+            navigation_handler._display_login_code({'link_code': '123456'})
+
+        message = mock_dialog().ok.call_args[0][1]
+        assert 'https://mubi.com/tv' in message
+        assert 'mubi.com/android' not in message
+        assert '123456' in message
+
     def test_log_out(self, navigation_handler, mock_session):
         """Test logout process."""
         with patch('xbmcgui.Dialog') as mock_dialog:


### PR DESCRIPTION
## What & why

Two independent breakages caused by recent Mubi changes.

### 1. CI failure — new Mubi API field (`early_access_film_date_message`)
The scheduled **Mubi Shallow Sync** failed at the *Validate Schema* step (~1993/2058 items invalid):

> `Additional properties are not allowed ('early_access_film_date_message' was unexpected)`

Mubi added an `early_access_film_date_message` property to each country's availability (`consumable`) object. The per-country schema uses `additionalProperties: false`, so every item carrying it failed.

- Add the field to `backend/schemas/v1_schema.json` so existing shallow-sync data (which retains it for countries not re-scraped that run) validates. Other unknown fields are still rejected, keeping the API-change tripwire intact.
- Prune the field on fresh scrapes in `backend/scraper.py` to keep the JSON slim, matching the existing `film_date_message` handling.

### 2. Login broken — retired activation URL (fixes #43)
Mubi retired `https://mubi.com/android` (now returns **404**), which broke the device-code login. The current activation page is `https://mubi.com/tv`. The `link_code` API response carries no URL, so it must be set client-side.

- Update the login dialog URL in `navigation_handler.py`.
- Add a regression test guarding against reintroducing a dead URL.

## Verification
- Sample validation confirms the new field passes and other unknown fields still fail.
- Login + schema/digest tests pass locally.