### PR TITLE
Centralize external URLs + add endpoint healthcheck

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,66 @@
+name: Endpoint Healthcheck
+
+# Proactively verifies that the external pages/files the plugin depends on are
+# still live, so a retired/moved URL (e.g. Mubi's old login page returning 404)
+# is caught here instead of via a user bug report.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: pip install requests
+
+    - name: Run endpoint healthcheck
+      run: python scripts/healthcheck.py
+
+    - name: Notify on Failure
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+          const title = `🚨 Endpoint Healthcheck Failed`;
+
+          // De-duplicate: only open a new issue if one isn't already open.
+          const existing = await github.rest.issues.listForRepo({
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100,
+          });
+          const already = existing.data.find(
+            (i) => !i.pull_request && i.title === title
+          );
+
+          const body = `One or more external endpoints the plugin depends on failed the healthcheck.\n\n[View Run logs](${run_url})\n\nA URL the plugin hardcodes (Mubi login/web page or the catalog data file) may have moved or been retired. Check the run logs for which URL failed and update \`repo/plugin_video_mubi/resources/lib/constants.py\`.`;
+
+          if (already) {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: already.number,
+              body: `Still failing as of ${new Date().toISOString()}.\n\n[View Run logs](${run_url})`,
+            });
+          } else {
+            await github.rest.issues.create({ owner, repo, title, body });
+          }

--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+"""
+Centralized external URLs and endpoints used by the plugin.
+
+This module is intentionally dependency-free (no Kodi/`xbmc` imports) so it can
+be imported both by the addon at runtime *and* by CI tooling such as the
+endpoint healthcheck (`scripts/healthcheck.py`). Keeping every external URL in
+one place means a third party moving/retiring a page (as Mubi did with the old
+`https://mubi.com/android` login page) is caught in one auditable spot and can
+be verified automatically.
+"""
+
+# --- Mubi ---------------------------------------------------------------
+
+# Mubi REST API base.
+MUBI_API_URL = "https://api.mubi.com/"
+
+# Mubi website base. Used for Referer/Origin headers and client-country detection.
+MUBI_WEB_URL = "https://mubi.com"
+
+# Device / TV login activation page shown to the user during login.
+# NOTE: Mubi retired the previous page (https://mubi.com/android -> 404); the
+# device-code API response carries no URL, so this must be maintained here.
+MUBI_LOGIN_ACTIVATION_URL = "https://mubi.com/tv"
+
+# Widevine DRM license proxy used for playback.
+DRM_LICENSE_URL = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
+
+
+# --- Plugin's own hosted data -------------------------------------------
+
+# Pre-computed, compressed catalog published on this repo's `database` branch.
+CATALOG_FILMS_URL = (
+    "https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz"
+)
+
+
+# --- Healthcheck --------------------------------------------------------
+
+# External URLs the plugin depends on that must return a successful (2xx/3xx)
+# response. Checked on a schedule by scripts/healthcheck.py so that a retired or
+# moved page is surfaced proactively instead of via a user bug report.
+#
+# The API base (MUBI_API_URL) is deliberately excluded: it returns 404 on a bare
+# GET (there is no root endpoint), so it cannot be liveness-checked without an
+# authenticated call. The DRM license endpoint is likewise excluded (it only
+# responds to authenticated license POSTs).
+HEALTHCHECK_URLS = [
+    MUBI_WEB_URL,
+    MUBI_LOGIN_ACTIVATION_URL,
+    CATALOG_FILMS_URL,
+]

--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -51,3 +51,18 @@ HEALTHCHECK_URLS = [
     MUBI_LOGIN_ACTIVATION_URL,
     CATALOG_FILMS_URL,
 ]
+
+# Activation-URL drift canary.
+#
+# `https://mubi.com/activate` is Mubi's server-side pointer to wherever device
+# activation currently lives: it permanently (301) redirects to the real path.
+# Today that first hop is `/tv/activate`. Watching *that Location header* is an
+# authoritative early signal that Mubi moved the activation page (as it did when
+# it retired /android): the redirect target changes before/independently of our
+# hardcoded MUBI_LOGIN_ACTIVATION_URL breaking, and it names the new path.
+#
+# The healthcheck reads the first-hop Location (redirects OFF) and compares its
+# path to the baseline below; a mismatch means "review the login URL". Only the
+# path is compared, so Mubi returning an absolute vs relative Location is fine.
+MUBI_ACTIVATION_PROBE_URL = "https://mubi.com/activate"
+MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH = "/tv/activate"

--- a/repo/plugin_video_mubi/resources/lib/data_source.py
+++ b/repo/plugin_video_mubi/resources/lib/data_source.py
@@ -7,6 +7,11 @@ from abc import ABC, abstractmethod
 import datetime
 import dateutil.parser
 
+try:
+    from .constants import CATALOG_FILMS_URL
+except ImportError:  # imported as a top-level module (e.g. some test harnesses)
+    from constants import CATALOG_FILMS_URL
+
 class FilmDataSource:
     """
     Interface for a film data source.
@@ -239,7 +244,7 @@ class GithubDataSource(FilmDataSource):
     URL: https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz
     """
 
-    GITHUB_URL = "https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz"
+    GITHUB_URL = CATALOG_FILMS_URL
     SUPPORTED_VERSIONS = [1]  # Supported schema versions
 
     def get_films(self, *args, **kwargs) -> List[Dict[str, Any]]:

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -28,6 +28,7 @@ from requests.packages.urllib3.util.retry import Retry
 from typing import Optional, Tuple
 from .metadata import Metadata
 from .film import Film
+from .constants import MUBI_API_URL, MUBI_WEB_URL
 from .library import Library
 from .playback import generate_drm_license_key
 
@@ -51,7 +52,7 @@ class Mubi:
         :param session_manager: Instance of SessionManager to handle session data
         :type session_manager: SessionManager
         """
-        self.apiURL = 'https://api.mubi.com/'
+        self.apiURL = MUBI_API_URL
         self.UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0'
         self.session_manager = session_manager  # Use session manager for session-related data
         self.library = Library()  # Initialize the Library
@@ -397,7 +398,7 @@ class Mubi:
 
             fresh_session = fresh_requests.Session()
             fresh_session.cookies.clear()
-            response = fresh_session.get('https://mubi.com/', headers=headers, timeout=10)
+            response = fresh_session.get(f'{MUBI_WEB_URL}/', headers=headers, timeout=10)
 
             if response and response.status_code == 200:
                 country = re.findall(r'"Client-Country":"([^"]+?)"', response.text)
@@ -435,7 +436,7 @@ class Mubi:
         :return: Headers dictionary.
         :rtype: dict
         """
-        base_url = 'https://mubi.com'  # This is used for the Referer and Origin headers
+        base_url = MUBI_WEB_URL  # This is used for the Referer and Origin headers
 
         return {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
@@ -509,7 +510,7 @@ class Mubi:
         :return: Headers dictionary without Authorization token.
         :rtype: dict
         """
-        base_url = 'https://mubi.com'
+        base_url = MUBI_WEB_URL
         # Use provided country_code or fall back to session's client_country
         client_country = country_code if country_code else self.session_manager.client_country
 
@@ -531,7 +532,7 @@ class Mubi:
         :return: Headers dictionary with web client headers and Authorization token.
         :rtype: dict
         """
-        base_url = 'https://mubi.com'
+        base_url = MUBI_WEB_URL
         token = self.session_manager.token
         if not token:
             xbmc.log("No token found for web headers", xbmc.LOGERROR)

--- a/repo/plugin_video_mubi/resources/lib/navigation_handler.py
+++ b/repo/plugin_video_mubi/resources/lib/navigation_handler.py
@@ -11,6 +11,7 @@ from typing import Optional
 from .library import Library
 from .library import Library
 from .playback import play_with_inputstream_adaptive
+from .constants import MUBI_LOGIN_ACTIVATION_URL
 import datetime
 import dateutil.parser
 import requests
@@ -946,7 +947,7 @@ class NavigationHandler:
     def _display_login_code(self, code_info: dict):
         """ Helper method to display login code to the user """
         link_code = code_info['link_code']
-        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]https://mubi.com/tv[/B]")
+        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]{MUBI_LOGIN_ACTIVATION_URL}[/B]")
 
     def _handle_login_error(self, auth_response: dict):
         """ Handle login errors from the Mubi API """

--- a/repo/plugin_video_mubi/resources/lib/playback.py
+++ b/repo/plugin_video_mubi/resources/lib/playback.py
@@ -8,6 +8,7 @@ import xbmc
 import pathlib
 from .mpd_patcher import MPDPatcher
 from .local_server import LocalServer
+from .constants import MUBI_WEB_URL, DRM_LICENSE_URL
 
 def generate_drm_license_key(token, user_id):
     """
@@ -17,15 +18,15 @@ def generate_drm_license_key(token, user_id):
     :param user_id: The Mubi user ID.
     :return: A formatted DRM license key URL.
     """
-    drm_license_url = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
+    drm_license_url = DRM_LICENSE_URL
     dcd = json.dumps({"userId": user_id, "sessionId": token, "merchant": "mubi"})
     dcd_enc = base64.b64encode(dcd.encode()).decode()
 
     drm_headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
         'dt-custom-data': dcd_enc,
-        'Referer': 'https://mubi.com/',
-        'Origin': 'https://mubi.com',
+        'Referer': f'{MUBI_WEB_URL}/',
+        'Origin': MUBI_WEB_URL,
         'Content-Type': ''
     }
 
@@ -42,15 +43,15 @@ def generate_drm_config(token, user_id):
     :param user_id: The Mubi user ID.
     :return: A dictionary containing the DRM configuration for the new format.
     """
-    drm_license_url = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
+    drm_license_url = DRM_LICENSE_URL
     dcd = json.dumps({"userId": user_id, "sessionId": token, "merchant": "mubi"})
     dcd_enc = base64.b64encode(dcd.encode()).decode()
 
     drm_headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
         'dt-custom-data': dcd_enc,
-        'Referer': 'https://mubi.com/',
-        'Origin': 'https://mubi.com',
+        'Referer': f'{MUBI_WEB_URL}/',
+        'Origin': MUBI_WEB_URL,
         'Content-Type': ''
     }
 
@@ -106,8 +107,8 @@ def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, su
         # Set the headers that will be used for the license and manifest
         stream_headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-            'Referer': 'https://mubi.com/',
-            'Origin': 'https://mubi.com'
+            'Referer': f'{MUBI_WEB_URL}/',
+            'Origin': MUBI_WEB_URL
         }
 
         headers_str = "&".join([f"{k}={v}" for k, v in stream_headers.items()])

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+External-endpoint healthcheck.
+
+Requests every URL the plugin depends on (see
+`repo/plugin_video_mubi/resources/lib/constants.py::HEALTHCHECK_URLS`) and fails
+if any returns an unsuccessful HTTP status or is unreachable.
+
+This exists because a third party retiring/moving a page it hosts (e.g. Mubi
+retiring https://mubi.com/android -> 404, which silently broke plugin login) is
+invisible to unit tests: the hardcoded string is still "correct", only the
+remote server changed. Only a live request against the real URL catches it.
+
+Run locally:   python scripts/healthcheck.py
+Exit code 0 = all healthy, 1 = one or more failed.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import requests
+
+# Import the constants module directly by path so we don't pull in the Kodi
+# addon package (which imports `xbmc` and friends unavailable in CI).
+_CONSTANTS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "repo"
+    / "plugin_video_mubi"
+    / "resources"
+    / "lib"
+    / "constants.py"
+)
+
+_spec = importlib.util.spec_from_file_location("mubi_constants", _CONSTANTS_PATH)
+_constants = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_constants)
+
+HEALTHCHECK_URLS = _constants.HEALTHCHECK_URLS
+
+# A real browser UA; some sites reject the default requests UA with a 403.
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) "
+    "Gecko/20100101 Firefox/125.0"
+)
+TIMEOUT = 20
+
+
+def check(url):
+    """Return (ok: bool, detail: str) for a single URL."""
+    try:
+        resp = requests.get(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            timeout=TIMEOUT,
+            allow_redirects=True,
+        )
+    except requests.RequestException as exc:
+        return False, f"unreachable: {exc.__class__.__name__}: {exc}"
+
+    # 2xx and 3xx are healthy; 4xx/5xx mean the page is gone or broken.
+    if resp.status_code < 400:
+        return True, f"HTTP {resp.status_code}"
+    return False, f"HTTP {resp.status_code}"
+
+
+def main():
+    print("Checking external endpoints the plugin depends on...\n")
+    failures = []
+    for url in HEALTHCHECK_URLS:
+        ok, detail = check(url)
+        symbol = "OK  " if ok else "FAIL"
+        print(f"  [{symbol}] {url}  ({detail})")
+        if not ok:
+            failures.append((url, detail))
+
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(HEALTHCHECK_URLS)} endpoint(s) FAILED:")
+        for url, detail in failures:
+            print(f"  - {url}: {detail}")
+        return 1
+
+    print(f"All {len(HEALTHCHECK_URLS)} endpoints healthy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -20,6 +20,7 @@ Exit code 0 = all healthy, 1 = one or more failed.
 import importlib.util
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import requests
 
@@ -39,6 +40,8 @@ _constants = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_constants)
 
 HEALTHCHECK_URLS = _constants.HEALTHCHECK_URLS
+ACTIVATION_PROBE_URL = _constants.MUBI_ACTIVATION_PROBE_URL
+ACTIVATION_EXPECTED_REDIRECT_PATH = _constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH
 
 # A real browser UA; some sites reject the default requests UA with a 403.
 USER_AGENT = (
@@ -66,6 +69,45 @@ def check(url):
     return False, f"HTTP {resp.status_code}"
 
 
+def check_activation_redirect():
+    """Drift canary for the device-activation URL.
+
+    `MUBI_ACTIVATION_PROBE_URL` (/activate) is Mubi's own permanent redirect to
+    wherever activation currently lives. We read that first-hop Location WITHOUT
+    following it and compare its path to the expected baseline. A mismatch is the
+    early signal that Mubi moved the activation page (as with /android) -- it
+    names the new path and can fire while the hardcoded login URL still 200s.
+
+    Return (ok: bool, detail: str).
+    """
+    try:
+        resp = requests.get(
+            ACTIVATION_PROBE_URL,
+            headers={"User-Agent": USER_AGENT},
+            timeout=TIMEOUT,
+            allow_redirects=False,
+        )
+    except requests.RequestException as exc:
+        return False, f"unreachable: {exc.__class__.__name__}: {exc}"
+
+    if not (300 <= resp.status_code < 400):
+        return False, (
+            f"expected a redirect to {ACTIVATION_EXPECTED_REDIRECT_PATH!r}, "
+            f"got HTTP {resp.status_code} (Mubi changed activation behaviour)"
+        )
+
+    location = resp.headers.get("Location", "")
+    # Compare only the path so an absolute vs relative Location doesn't matter.
+    actual_path = urlsplit(location).path
+    if actual_path == ACTIVATION_EXPECTED_REDIRECT_PATH:
+        return True, f"HTTP {resp.status_code} -> {actual_path}"
+    return False, (
+        f"activation URL DRIFTED: /activate now redirects to {actual_path!r} "
+        f"(baseline {ACTIVATION_EXPECTED_REDIRECT_PATH!r}) -- update "
+        f"MUBI_LOGIN_ACTIVATION_URL / the baseline in constants.py"
+    )
+
+
 def main():
     print("Checking external endpoints the plugin depends on...\n")
     failures = []
@@ -76,14 +118,22 @@ def main():
         if not ok:
             failures.append((url, detail))
 
+    # Drift canary (separate from the plain 200 checks above).
+    ok, detail = check_activation_redirect()
+    symbol = "OK  " if ok else "FAIL"
+    print(f"  [{symbol}] activation-redirect canary  ({detail})")
+    if not ok:
+        failures.append((ACTIVATION_PROBE_URL, detail))
+
+    total = len(HEALTHCHECK_URLS) + 1
     print()
     if failures:
-        print(f"{len(failures)} of {len(HEALTHCHECK_URLS)} endpoint(s) FAILED:")
+        print(f"{len(failures)} of {total} check(s) FAILED:")
         for url, detail in failures:
             print(f"  - {url}: {detail}")
         return 1
 
-    print(f"All {len(HEALTHCHECK_URLS)} endpoints healthy.")
+    print(f"All {total} checks healthy.")
     return 0
 
 

--- a/tests/plugin_video_mubi/test_url_constants.py
+++ b/tests/plugin_video_mubi/test_url_constants.py
@@ -34,3 +34,8 @@ class TestUrlConstants:
         from resources.lib import data_source
 
         assert data_source.GithubDataSource.GITHUB_URL == constants.CATALOG_FILMS_URL
+
+    def test_activation_drift_canary_baselines_present(self):
+        assert constants.MUBI_ACTIVATION_PROBE_URL.startswith("https://")
+        # The expected redirect target is compared as a path, so it must be one.
+        assert constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH.startswith("/")

--- a/tests/plugin_video_mubi/test_url_constants.py
+++ b/tests/plugin_video_mubi/test_url_constants.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Tests for the centralized external-URL constants (resources.lib.constants)."""
+
+from resources.lib import constants
+
+
+class TestUrlConstants:
+    def test_all_urls_are_https(self):
+        for name in (
+            "MUBI_API_URL",
+            "MUBI_WEB_URL",
+            "MUBI_LOGIN_ACTIVATION_URL",
+            "DRM_LICENSE_URL",
+            "CATALOG_FILMS_URL",
+        ):
+            value = getattr(constants, name)
+            assert value.startswith("https://"), f"{name} must be https"
+
+    def test_login_activation_url_is_current(self):
+        # Guard the fix for the retired mubi.com/android page.
+        assert constants.MUBI_LOGIN_ACTIVATION_URL == "https://mubi.com/tv"
+        assert "android" not in constants.MUBI_LOGIN_ACTIVATION_URL
+
+    def test_healthcheck_urls_cover_user_facing_endpoints(self):
+        assert constants.MUBI_WEB_URL in constants.HEALTHCHECK_URLS
+        assert constants.MUBI_LOGIN_ACTIVATION_URL in constants.HEALTHCHECK_URLS
+        assert constants.CATALOG_FILMS_URL in constants.HEALTHCHECK_URLS
+
+    def test_healthcheck_excludes_bare_api_base(self):
+        # api.mubi.com/ returns 404 on a bare GET, so it must not be strict-checked.
+        assert constants.MUBI_API_URL not in constants.HEALTHCHECK_URLS
+
+    def test_data_source_uses_catalog_constant(self):
+        from resources.lib import data_source
+
+        assert data_source.GithubDataSource.GITHUB_URL == constants.CATALOG_FILMS_URL

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/healthcheck.py status classification."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "healthcheck.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("healthcheck", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+healthcheck = _load()
+
+
+def _response(status):
+    resp = MagicMock()
+    resp.status_code = status
+    return resp
+
+
+class TestCheck:
+    @pytest.mark.parametrize("status", [200, 201, 301, 302, 399])
+    def test_success_and_redirect_are_healthy(self, status):
+        with patch.object(healthcheck.requests, "get", return_value=_response(status)):
+            ok, detail = healthcheck.check("https://example.com")
+        assert ok is True
+        assert str(status) in detail
+
+    @pytest.mark.parametrize("status", [400, 404, 410, 500, 503])
+    def test_client_and_server_errors_fail(self, status):
+        with patch.object(healthcheck.requests, "get", return_value=_response(status)):
+            ok, detail = healthcheck.check("https://example.com")
+        assert ok is False
+        assert str(status) in detail
+
+    def test_unreachable_host_fails_gracefully(self):
+        with patch.object(
+            healthcheck.requests,
+            "get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            ok, detail = healthcheck.check("https://nope.invalid")
+        assert ok is False
+        assert "unreachable" in detail
+
+    def test_main_returns_nonzero_when_any_fail(self):
+        with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a", "https://b"]):
+            with patch.object(
+                healthcheck,
+                "check",
+                side_effect=[(True, "HTTP 200"), (False, "HTTP 404")],
+            ):
+                assert healthcheck.main() == 1
+
+    def test_main_returns_zero_when_all_pass(self):
+        with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a"]):
+            with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
+                assert healthcheck.main() == 0

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -21,9 +21,10 @@ def _load():
 healthcheck = _load()
 
 
-def _response(status):
+def _response(status, headers=None):
     resp = MagicMock()
     resp.status_code = status
+    resp.headers = headers or {}
     return resp
 
 
@@ -59,9 +60,92 @@ class TestCheck:
                 "check",
                 side_effect=[(True, "HTTP 200"), (False, "HTTP 404")],
             ):
-                assert healthcheck.main() == 1
+                with patch.object(
+                    healthcheck,
+                    "check_activation_redirect",
+                    return_value=(True, "HTTP 301 -> /tv/activate"),
+                ):
+                    assert healthcheck.main() == 1
 
     def test_main_returns_zero_when_all_pass(self):
         with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a"]):
             with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
-                assert healthcheck.main() == 0
+                with patch.object(
+                    healthcheck,
+                    "check_activation_redirect",
+                    return_value=(True, "HTTP 301 -> /tv/activate"),
+                ):
+                    assert healthcheck.main() == 0
+
+
+class TestActivationRedirectCanary:
+    def test_matching_relative_location_is_healthy(self):
+        with patch.object(
+            healthcheck,
+            "ACTIVATION_EXPECTED_REDIRECT_PATH",
+            "/tv/activate",
+        ):
+            with patch.object(
+                healthcheck.requests,
+                "get",
+                return_value=_response(301, {"Location": "/tv/activate"}),
+            ):
+                ok, detail = healthcheck.check_activation_redirect()
+        assert ok is True
+        assert "/tv/activate" in detail
+
+    def test_absolute_location_compares_by_path(self):
+        with patch.object(
+            healthcheck, "ACTIVATION_EXPECTED_REDIRECT_PATH", "/tv/activate"
+        ):
+            with patch.object(
+                healthcheck.requests,
+                "get",
+                return_value=_response(
+                    301, {"Location": "https://mubi.com/tv/activate"}
+                ),
+            ):
+                ok, _ = healthcheck.check_activation_redirect()
+        assert ok is True
+
+    def test_drifted_location_fails_and_names_new_path(self):
+        with patch.object(
+            healthcheck, "ACTIVATION_EXPECTED_REDIRECT_PATH", "/tv/activate"
+        ):
+            with patch.object(
+                healthcheck.requests,
+                "get",
+                return_value=_response(301, {"Location": "/connect/device"}),
+            ):
+                ok, detail = healthcheck.check_activation_redirect()
+        assert ok is False
+        assert "DRIFTED" in detail
+        assert "/connect/device" in detail  # names the new path
+
+    def test_non_redirect_status_fails(self):
+        with patch.object(
+            healthcheck.requests, "get", return_value=_response(200, {})
+        ):
+            ok, detail = healthcheck.check_activation_redirect()
+        assert ok is False
+        assert "200" in detail
+
+    def test_unreachable_fails_gracefully(self):
+        with patch.object(
+            healthcheck.requests,
+            "get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            ok, detail = healthcheck.check_activation_redirect()
+        assert ok is False
+        assert "unreachable" in detail
+
+    def test_main_fails_when_canary_drifts(self):
+        with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a"]):
+            with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
+                with patch.object(
+                    healthcheck,
+                    "check_activation_redirect",
+                    return_value=(False, "activation URL DRIFTED"),
+                ):
+                    assert healthcheck.main() == 1


### PR DESCRIPTION
## What & why

Follow-up to the login 404 (#43). That bug was a hardcoded external URL that silently went stale — invisible to tests because the string was "correct", only Mubi's server changed. This PR reduces the chance of a repeat and catches it fast when it happens.

### 1. Centralize external URLs
External URLs were scattered across the addon (login page, API base, Mubi web base, DRM license, catalog data file). Introduces `resources/lib/constants.py` as a single, dependency-free source of truth, and wires `mubi.py`, `navigation_handler.py`, `playback.py`, and `data_source.py` to it.

Being import-safe (no Kodi/`xbmc` imports) means CI tooling can import the same list. `data_source.py` keeps a top-level import fallback because an existing integration test imports it as a bare module.

### 2. Scheduled endpoint healthcheck
- `scripts/healthcheck.py` — requests every URL in `constants.HEALTHCHECK_URLS` and fails on a non-2xx/3xx or unreachable response.
- `.github/workflows/healthcheck.yml` — daily cron + manual dispatch, reusing the existing notify-on-failure pattern but **de-duplicating**: a persistent outage comments on the open issue instead of opening a new one every day.

Had this existed, Mubi retiring `mubi.com/android` would have opened an issue within a day instead of waiting for a user report.

**Deliberately excluded from the strict check:** the API base (`api.mubi.com/` returns 404 on a bare GET — no root endpoint) and the DRM license endpoint (responds only to authenticated POSTs). Verifying those needs authenticated calls, out of scope here.

## Verification
- Full suite: **745 passed, 16 skipped** (backend + integration + addon).
- New tests: `test_url_constants.py` (constants shape + wiring) and `test_healthcheck.py` (status classification, all mocked — no network).
- Ran `scripts/healthcheck.py` live: all 3 endpoints return 200.