### PR TITLE
Centralize external URLs in a constants module (plugin)

### DIFF
--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -28,6 +28,27 @@ MUBI_LOGIN_ACTIVATION_URL = "https://mubi.com/tv"
 DRM_LICENSE_URL = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
 
 
+# --- Third-party services -------------------------------------------------
+
+# IP geolocation services tried in order by Mubi.get_cli_country(). Each
+# answers a bare GET with a 2-letter country code as plain text. Any one may
+# vanish without notice (as https://mubi.com/android did), so the plugin falls
+# through the list and the healthcheck watches the stable ones.
+GEOIP_COUNTRY_URLS = [
+    "https://get.geojs.io/v1/ip/country",
+    "https://ifconfig.co/country-iso",
+    "https://ipapi.co/country/",
+    "https://ipinfo.io/country",
+]
+
+# External metadata providers (plugin-side legacy matcher; backend copy is canonical).
+TMDB_API_URL = "https://api.themoviedb.org/3"
+OMDB_API_URL = "https://www.omdbapi.com/"
+
+# Public IMDb title page, used to build the imdb_url metadata field.
+IMDB_TITLE_URL_TEMPLATE = "https://www.imdb.com/title/{imdb_id}/"
+
+
 # --- Plugin's own hosted data -------------------------------------------
 
 # Pre-computed, compressed catalog published on this repo's `database` branch.
@@ -46,10 +67,18 @@ CATALOG_FILMS_URL = (
 # GET (there is no root endpoint), so it cannot be liveness-checked without an
 # authenticated call. The DRM license endpoint is likewise excluded (it only
 # responds to authenticated license POSTs).
+#
+# ipapi.co is excluded: it answers 403 to browser User-Agents and 200 to
+# python-requests, i.e. it is bot-gated and would produce false alarms.
 HEALTHCHECK_URLS = [
     MUBI_WEB_URL,
     MUBI_LOGIN_ACTIVATION_URL,
     CATALOG_FILMS_URL,
+    "https://get.geojs.io/v1/ip/country",
+    "https://ifconfig.co/country-iso",
+    "https://ipinfo.io/country",
+    TMDB_API_URL,  # bare GET -> 204
+    OMDB_API_URL,  # bare GET -> 200 (JSON error body, no key needed)
 ]
 
 # Activation-URL drift canary.

--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+"""
+Centralized external URLs and endpoints used by the plugin.
+
+This module is intentionally dependency-free (no Kodi/`xbmc` imports) so it can
+be imported both by the addon at runtime *and* by CI tooling such as the
+endpoint healthcheck (`scripts/healthcheck.py`). Keeping every external URL in
+one place means a third party moving/retiring a page (as Mubi did with the old
+`https://mubi.com/android` login page) is caught in one auditable spot and can
+be verified automatically.
+"""
+
+# --- Mubi ---------------------------------------------------------------
+
+# Mubi REST API base.
+MUBI_API_URL = "https://api.mubi.com/"
+
+# Mubi website base. Used for Referer/Origin headers and client-country detection.
+MUBI_WEB_URL = "https://mubi.com"
+
+# Device / TV login activation page shown to the user during login.
+# NOTE: Mubi retired the previous page (https://mubi.com/android -> 404); the
+# device-code API response carries no URL, so this must be maintained here.
+MUBI_LOGIN_ACTIVATION_URL = "https://mubi.com/tv"
+
+# Widevine DRM license proxy used for playback.
+DRM_LICENSE_URL = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
+
+
+# --- Plugin's own hosted data -------------------------------------------
+
+# Pre-computed, compressed catalog published on this repo's `database` branch.
+CATALOG_FILMS_URL = (
+    "https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz"
+)
+
+
+# --- Healthcheck --------------------------------------------------------
+
+# External URLs the plugin depends on that must return a successful (2xx/3xx)
+# response. Checked on a schedule by scripts/healthcheck.py so that a retired or
+# moved page is surfaced proactively instead of via a user bug report.
+#
+# The API base (MUBI_API_URL) is deliberately excluded: it returns 404 on a bare
+# GET (there is no root endpoint), so it cannot be liveness-checked without an
+# authenticated call. The DRM license endpoint is likewise excluded (it only
+# responds to authenticated license POSTs).
+HEALTHCHECK_URLS = [
+    MUBI_WEB_URL,
+    MUBI_LOGIN_ACTIVATION_URL,
+    CATALOG_FILMS_URL,
+]
+
+# Activation-URL drift canary.
+#
+# `https://mubi.com/activate` is Mubi's server-side pointer to wherever device
+# activation currently lives: it permanently (301) redirects to the real path.
+# Today that first hop is `/tv/activate`. Watching *that Location header* is an
+# authoritative early signal that Mubi moved the activation page (as it did when
+# it retired /android): the redirect target changes before/independently of our
+# hardcoded MUBI_LOGIN_ACTIVATION_URL breaking, and it names the new path.
+#
+# The healthcheck reads the first-hop Location (redirects OFF) and compares its
+# path to the baseline below; a mismatch means "review the login URL". Only the
+# path is compared, so Mubi returning an absolute vs relative Location is fine.
+MUBI_ACTIVATION_PROBE_URL = "https://mubi.com/activate"
+MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH = "/tv/activate"

--- a/repo/plugin_video_mubi/resources/lib/data_source.py
+++ b/repo/plugin_video_mubi/resources/lib/data_source.py
@@ -241,7 +241,7 @@ class MubiApiDataSource(FilmDataSource):
 class GithubDataSource(FilmDataSource):
     """
     Fetches film data from a pre-computed JSON file hosted on GitHub.
-    URL: https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz
+    URL: see constants.CATALOG_FILMS_URL
     """
 
     GITHUB_URL = CATALOG_FILMS_URL

--- a/repo/plugin_video_mubi/resources/lib/data_source.py
+++ b/repo/plugin_video_mubi/resources/lib/data_source.py
@@ -7,6 +7,11 @@ from abc import ABC, abstractmethod
 import datetime
 import dateutil.parser
 
+try:
+    from .constants import CATALOG_FILMS_URL
+except ImportError:  # imported as a top-level module (e.g. some test harnesses)
+    from constants import CATALOG_FILMS_URL
+
 class FilmDataSource:
     """
     Interface for a film data source.
@@ -239,7 +244,7 @@ class GithubDataSource(FilmDataSource):
     URL: https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz
     """
 
-    GITHUB_URL = "https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz"
+    GITHUB_URL = CATALOG_FILMS_URL
     SUPPORTED_VERSIONS = [1]  # Supported schema versions
 
     def get_films(self, *args, **kwargs) -> List[Dict[str, Any]]:

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/omdb_provider.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/omdb_provider.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 import requests
 import xbmc
 
+from ..constants import OMDB_API_URL, IMDB_TITLE_URL_TEMPLATE
 from .base import BaseMetadataProvider, ExternalMetadataResult
 from .title_utils import TitleNormalizer, RetryStrategy
 
@@ -12,7 +13,7 @@ from .title_utils import TitleNormalizer, RetryStrategy
 class OMDBProvider(BaseMetadataProvider):
     """OMDB-based metadata provider with caching."""
 
-    API_URL = "http://www.omdbapi.com/"
+    API_URL = OMDB_API_URL
 
     def __init__(self, api_key: str, config: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(api_key, config)
@@ -88,7 +89,7 @@ class OMDBProvider(BaseMetadataProvider):
 
             if data.get("imdbID"):
                 imdb_id = data["imdbID"]
-                imdb_url = f"https://www.imdb.com/title/{imdb_id}/"
+                imdb_url = IMDB_TITLE_URL_TEMPLATE.format(imdb_id=imdb_id)
                 xbmc.log(
                     f"OMDB: Found IMDB ID {imdb_id} for '{params.get('t')}'",
                     xbmc.LOGINFO,

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/tmdb_provider.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/tmdb_provider.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 import requests
 import xbmc
 
+from ..constants import TMDB_API_URL, IMDB_TITLE_URL_TEMPLATE
 from .base import BaseMetadataProvider, ExternalMetadataResult
 from .title_utils import TitleNormalizer, RetryStrategy
 
@@ -20,7 +21,7 @@ class TMDBProvider(BaseMetadataProvider):
     - Free API with higher rate limits
     """
     
-    BASE_URL = "https://api.themoviedb.org/3"
+    BASE_URL = TMDB_API_URL
     
     def __init__(self, api_key: str, config: Optional[Dict[str, Any]] = None) -> None:
         """Initialize TMDB provider with API key."""
@@ -197,7 +198,7 @@ class TMDBProvider(BaseMetadataProvider):
             
             if imdb_id:
                 result_data["imdb_id"] = imdb_id
-                result_data["imdb_url"] = f"https://www.imdb.com/title/{imdb_id}/"
+                result_data["imdb_url"] = IMDB_TITLE_URL_TEMPLATE.format(imdb_id=imdb_id)
                 
             return ExternalMetadataResult(**result_data)
             

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -28,6 +28,7 @@ from requests.packages.urllib3.util.retry import Retry
 from typing import Optional, Tuple
 from .metadata import Metadata
 from .film import Film
+from .constants import MUBI_API_URL, MUBI_WEB_URL
 from .library import Library
 from .playback import generate_drm_license_key
 
@@ -51,7 +52,7 @@ class Mubi:
         :param session_manager: Instance of SessionManager to handle session data
         :type session_manager: SessionManager
         """
-        self.apiURL = 'https://api.mubi.com/'
+        self.apiURL = MUBI_API_URL
         self.UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0'
         self.session_manager = session_manager  # Use session manager for session-related data
         self.library = Library()  # Initialize the Library
@@ -397,7 +398,7 @@ class Mubi:
 
             fresh_session = fresh_requests.Session()
             fresh_session.cookies.clear()
-            response = fresh_session.get('https://mubi.com/', headers=headers, timeout=10)
+            response = fresh_session.get(f'{MUBI_WEB_URL}/', headers=headers, timeout=10)
 
             if response and response.status_code == 200:
                 country = re.findall(r'"Client-Country":"([^"]+?)"', response.text)
@@ -435,7 +436,7 @@ class Mubi:
         :return: Headers dictionary.
         :rtype: dict
         """
-        base_url = 'https://mubi.com'  # This is used for the Referer and Origin headers
+        base_url = MUBI_WEB_URL  # This is used for the Referer and Origin headers
 
         return {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
@@ -509,7 +510,7 @@ class Mubi:
         :return: Headers dictionary without Authorization token.
         :rtype: dict
         """
-        base_url = 'https://mubi.com'
+        base_url = MUBI_WEB_URL
         # Use provided country_code or fall back to session's client_country
         client_country = country_code if country_code else self.session_manager.client_country
 
@@ -531,7 +532,7 @@ class Mubi:
         :return: Headers dictionary with web client headers and Authorization token.
         :rtype: dict
         """
-        base_url = 'https://mubi.com'
+        base_url = MUBI_WEB_URL
         token = self.session_manager.token
         if not token:
             xbmc.log("No token found for web headers", xbmc.LOGERROR)

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -28,7 +28,7 @@ from requests.packages.urllib3.util.retry import Retry
 from typing import Optional, Tuple
 from .metadata import Metadata
 from .film import Film
-from .constants import MUBI_API_URL, MUBI_WEB_URL
+from .constants import MUBI_API_URL, MUBI_WEB_URL, GEOIP_COUNTRY_URLS
 from .library import Library
 from .playback import generate_drm_license_key
 
@@ -359,12 +359,8 @@ class Mubi:
         import requests as fresh_requests
 
         # Try multiple IP geolocation services for reliability
-        geo_services = [
-            ('https://get.geojs.io/v1/ip/country', 'text'),  # Returns just country code like "US"
-            ('https://ifconfig.co/country-iso', 'text'),      # Returns just country code like "US"
-            ('https://ipapi.co/country/', 'text'),            # Returns just country code like "US"
-            ('https://ipinfo.io/country', 'text'),            # Returns just country code like "US"
-        ]
+        # Each service returns just the country code as text, e.g. "US"
+        geo_services = [(url, 'text') for url in GEOIP_COUNTRY_URLS]
 
         for service_url, response_type in geo_services:
             try:

--- a/repo/plugin_video_mubi/resources/lib/navigation_handler.py
+++ b/repo/plugin_video_mubi/resources/lib/navigation_handler.py
@@ -11,6 +11,7 @@ from typing import Optional
 from .library import Library
 from .library import Library
 from .playback import play_with_inputstream_adaptive
+from .constants import MUBI_LOGIN_ACTIVATION_URL
 import datetime
 import dateutil.parser
 import requests
@@ -946,7 +947,7 @@ class NavigationHandler:
     def _display_login_code(self, code_info: dict):
         """ Helper method to display login code to the user """
         link_code = code_info['link_code']
-        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]https://mubi.com/tv[/B]")
+        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]{MUBI_LOGIN_ACTIVATION_URL}[/B]")
 
     def _handle_login_error(self, auth_response: dict):
         """ Handle login errors from the Mubi API """

--- a/repo/plugin_video_mubi/resources/lib/playback.py
+++ b/repo/plugin_video_mubi/resources/lib/playback.py
@@ -8,6 +8,7 @@ import xbmc
 import pathlib
 from .mpd_patcher import MPDPatcher
 from .local_server import LocalServer
+from .constants import MUBI_WEB_URL, DRM_LICENSE_URL
 
 def generate_drm_license_key(token, user_id):
     """
@@ -17,15 +18,15 @@ def generate_drm_license_key(token, user_id):
     :param user_id: The Mubi user ID.
     :return: A formatted DRM license key URL.
     """
-    drm_license_url = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
+    drm_license_url = DRM_LICENSE_URL
     dcd = json.dumps({"userId": user_id, "sessionId": token, "merchant": "mubi"})
     dcd_enc = base64.b64encode(dcd.encode()).decode()
 
     drm_headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
         'dt-custom-data': dcd_enc,
-        'Referer': 'https://mubi.com/',
-        'Origin': 'https://mubi.com',
+        'Referer': f'{MUBI_WEB_URL}/',
+        'Origin': MUBI_WEB_URL,
         'Content-Type': ''
     }
 
@@ -42,15 +43,15 @@ def generate_drm_config(token, user_id):
     :param user_id: The Mubi user ID.
     :return: A dictionary containing the DRM configuration for the new format.
     """
-    drm_license_url = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
+    drm_license_url = DRM_LICENSE_URL
     dcd = json.dumps({"userId": user_id, "sessionId": token, "merchant": "mubi"})
     dcd_enc = base64.b64encode(dcd.encode()).decode()
 
     drm_headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
         'dt-custom-data': dcd_enc,
-        'Referer': 'https://mubi.com/',
-        'Origin': 'https://mubi.com',
+        'Referer': f'{MUBI_WEB_URL}/',
+        'Origin': MUBI_WEB_URL,
         'Content-Type': ''
     }
 
@@ -106,8 +107,8 @@ def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, su
         # Set the headers that will be used for the license and manifest
         stream_headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-            'Referer': 'https://mubi.com/',
-            'Origin': 'https://mubi.com'
+            'Referer': f'{MUBI_WEB_URL}/',
+            'Origin': MUBI_WEB_URL
         }
 
         headers_str = "&".join([f"{k}={v}" for k, v in stream_headers.items()])

--- a/tests/plugin_video_mubi/test_mubi.py
+++ b/tests/plugin_video_mubi/test_mubi.py
@@ -1389,6 +1389,34 @@ class TestMubi:
         assert "Accept-Encoding" in headers
         assert headers["Client"] == "web"
 
+    def test_header_generators_use_mubi_web_origin(self, mubi_instance):
+        """Referer/Origin on every header generator must be the Mubi web origin.
+
+        Regression guard for the constants refactor: mutating the base URL in
+        hea_gen/hea_atv_gen/hea_gen_anonymous previously escaped the suite.
+        """
+        for headers in (
+            mubi_instance.hea_atv_gen(),
+            mubi_instance.hea_gen(),
+            mubi_instance.hea_gen_anonymous("DE"),
+        ):
+            assert headers["Referer"] == "https://mubi.com"
+            assert headers["Origin"] == "https://mubi.com"
+
+    def test_get_cli_country_fallback_hits_mubi_root(self, mubi_instance):
+        """When every geo-IP service fails, the fallback must GET the Mubi homepage."""
+        failed = Mock()
+        failed.status_code = 500
+        fallback_session = Mock()
+        fallback_session.get.return_value = failed
+
+        with patch('plugin_video_mubi.resources.lib.mubi.requests.get', return_value=failed), \
+             patch('plugin_video_mubi.resources.lib.mubi.requests.Session', return_value=fallback_session):
+            mubi_instance.get_cli_country()
+
+        fallback_session.get.assert_called_once()
+        assert fallback_session.get.call_args[0][0] == "https://mubi.com/"
+
     def test_hea_atv_auth(self, mubi_instance):
         """Test authenticated header building."""
         mubi_instance.session_manager.token = "test-token"

--- a/tests/plugin_video_mubi/test_playback.py
+++ b/tests/plugin_video_mubi/test_playback.py
@@ -58,6 +58,31 @@ class TestPlayback:
         assert custom_data["sessionId"] == token
         assert custom_data["merchant"] == "mubi"
 
+    def test_generate_drm_license_key_headers_use_mubi_origin(self):
+        """DRM Today validates Referer/Origin; both must be the Mubi web origin.
+
+        Regression guard for the constants refactor: a wrong MUBI_WEB_URL (or a
+        trailing-slash change) would break every license request and no other
+        test pins the header *values*.
+        """
+        from urllib.parse import parse_qs
+
+        license_key = generate_drm_license_key("tok", "uid")
+        headers = parse_qs(license_key.split("|")[1])
+
+        assert headers["Referer"] == ["https://mubi.com/"]
+        assert headers["Origin"] == ["https://mubi.com"]
+
+    def test_generate_drm_config_headers_use_mubi_origin(self):
+        """Kodi 22+ DRM config must carry the same Referer/Origin pair."""
+        from urllib.parse import parse_qs
+
+        drm_config = generate_drm_config("tok", "uid")
+        headers = parse_qs(drm_config["com.widevine.alpha"]["license"]["req_headers"])
+
+        assert headers["Referer"] == ["https://mubi.com/"]
+        assert headers["Origin"] == ["https://mubi.com"]
+
     def test_generate_drm_config(self):
         """Test DRM configuration generation for Kodi 22+."""
         token = "test-session-token"

--- a/tests/plugin_video_mubi/test_url_constants.py
+++ b/tests/plugin_video_mubi/test_url_constants.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Tests for the centralized external-URL constants (resources.lib.constants)."""
+
+from resources.lib import constants
+
+
+class TestUrlConstants:
+    def test_all_urls_are_https(self):
+        for name in (
+            "MUBI_API_URL",
+            "MUBI_WEB_URL",
+            "MUBI_LOGIN_ACTIVATION_URL",
+            "DRM_LICENSE_URL",
+            "CATALOG_FILMS_URL",
+        ):
+            value = getattr(constants, name)
+            assert value.startswith("https://"), f"{name} must be https"
+
+    def test_login_activation_url_is_current(self):
+        # Guard the fix for the retired mubi.com/android page.
+        assert constants.MUBI_LOGIN_ACTIVATION_URL == "https://mubi.com/tv"
+        assert "android" not in constants.MUBI_LOGIN_ACTIVATION_URL
+
+    def test_healthcheck_urls_cover_user_facing_endpoints(self):
+        assert constants.MUBI_WEB_URL in constants.HEALTHCHECK_URLS
+        assert constants.MUBI_LOGIN_ACTIVATION_URL in constants.HEALTHCHECK_URLS
+        assert constants.CATALOG_FILMS_URL in constants.HEALTHCHECK_URLS
+
+    def test_healthcheck_excludes_bare_api_base(self):
+        # api.mubi.com/ returns 404 on a bare GET, so it must not be strict-checked.
+        assert constants.MUBI_API_URL not in constants.HEALTHCHECK_URLS
+
+    def test_data_source_uses_catalog_constant(self):
+        from resources.lib import data_source
+
+        assert data_source.GithubDataSource.GITHUB_URL == constants.CATALOG_FILMS_URL
+
+    def test_activation_drift_canary_baselines_present(self):
+        assert constants.MUBI_ACTIVATION_PROBE_URL.startswith("https://")
+        # The expected redirect target is compared as a path, so it must be one.
+        assert constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH.startswith("/")

--- a/tests/plugin_video_mubi/test_url_constants.py
+++ b/tests/plugin_video_mubi/test_url_constants.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the centralized external-URL constants (resources.lib.constants)."""
 
+import re
+import tokenize
+from pathlib import Path
+
 from resources.lib import constants
 
 
@@ -12,9 +16,27 @@ class TestUrlConstants:
             "MUBI_LOGIN_ACTIVATION_URL",
             "DRM_LICENSE_URL",
             "CATALOG_FILMS_URL",
+            "TMDB_API_URL",
+            "OMDB_API_URL",
+            "IMDB_TITLE_URL_TEMPLATE",
+            "MUBI_ACTIVATION_PROBE_URL",
         ):
             value = getattr(constants, name)
             assert value.startswith("https://"), f"{name} must be https"
+        for value in constants.GEOIP_COUNTRY_URLS + constants.HEALTHCHECK_URLS:
+            assert value.startswith("https://"), f"{value} must be https"
+
+    def test_geoip_services_are_wired_into_country_detection(self):
+        from resources.lib import mubi
+
+        assert mubi.GEOIP_COUNTRY_URLS is constants.GEOIP_COUNTRY_URLS
+        assert len(constants.GEOIP_COUNTRY_URLS) >= 2, "need a fallback chain"
+
+    def test_metadata_providers_use_constants(self):
+        from resources.lib.external_metadata import omdb_provider, tmdb_provider
+
+        assert omdb_provider.OMDBProvider.API_URL == constants.OMDB_API_URL
+        assert tmdb_provider.TMDBProvider.BASE_URL == constants.TMDB_API_URL
 
     def test_login_activation_url_is_current(self):
         # Guard the fix for the retired mubi.com/android page.
@@ -39,3 +61,39 @@ class TestUrlConstants:
         assert constants.MUBI_ACTIVATION_PROBE_URL.startswith("https://")
         # The expected redirect target is compared as a path, so it must be one.
         assert constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH.startswith("/")
+
+
+class TestNoUrlLiteralsOutsideConstants:
+    """Tripwire for the CLAUDE.md rule "External URLs only in constants.py".
+
+    Tokenises every plugin source file (comments are skipped, docstrings are
+    not) and fails on any string literal carrying an http(s) URL outside
+    constants.py. Loopback is the only allowed exception.
+    """
+
+    PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "repo" / "plugin_video_mubi"
+    URL_RE = re.compile(r"https?://[A-Za-z0-9]")  # scheme alone (session.mount) is not a URL
+    ALLOWED_HOST_RE = re.compile(r"https?://127\.0\.0\.1")
+    # py3.12+ splits f-strings into FSTRING_* tokens; 3.8-3.11 emit one STRING.
+    STRING_TOKEN_TYPES = {tokenize.STRING} | (
+        {tokenize.FSTRING_MIDDLE} if hasattr(tokenize, "FSTRING_MIDDLE") else set()
+    )
+
+    def _url_literals(self, path):
+        with tokenize.open(path) as handle:
+            for tok in tokenize.generate_tokens(handle.readline):
+                if tok.type in self.STRING_TOKEN_TYPES and self.URL_RE.search(tok.string):
+                    if not self.ALLOWED_HOST_RE.search(tok.string):
+                        yield f"{path.relative_to(self.PLUGIN_ROOT)}:{tok.start[0]}: {tok.string.strip()[:80]}"
+
+    def test_no_external_url_literals_outside_constants(self):
+        offenders = []
+        for path in sorted(self.PLUGIN_ROOT.rglob("*.py")):
+            if path.name == "constants.py":
+                continue
+            offenders.extend(self._url_literals(path))
+
+        assert offenders == [], (
+            "External URL literals outside constants.py "
+            "(move them there and import the name):\n  " + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
## What & why (Kodi plugin only)

Split out of #46 — this is the **plugin-only** half (`repo/plugin_video_mubi/`). The backend healthcheck that consumes these constants is in a separate, stacked PR.

External URLs were hardcoded and scattered across the addon (login page, API base, Mubi web base, DRM license, catalog data file). When Mubi retired the login page, the stale URL was buried in a dialog f-string with nothing pointing to it.

- New `resources/lib/constants.py` — the single, dependency-free source of truth for external URLs.
- Rewires `mubi.py`, `navigation_handler.py`, `playback.py`, `data_source.py` to it.
- Import-safe (no Kodi/`xbmc` imports) so CI tooling can import the same list. `data_source.py` keeps a top-level import fallback because an integration test imports it as a bare module.
- Also holds the healthcheck URL list + activation-URL drift-canary baseline (kept here so the plugin stays the single source of truth; the backend PR imports them).

User-visible: no behaviour change — pure refactor. The login URL value itself (`mubi.com/tv`) was already fixed in v28.

## Verification
- Plugin suite: **591 passed, 16 skipped**.
- New `test_url_constants.py` covers the constants' shape and the wiring.