### PR TITLE
Add scheduled endpoint healthcheck + drift canary (CI)

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -30,10 +30,14 @@ jobs:
       run: pip install requests
 
     - name: Run endpoint healthcheck
+      id: healthcheck
       run: python scripts/healthcheck.py
 
     - name: Notify on Failure
-      if: failure()
+      # Gate on the check step itself, not bare failure(): a broken checkout or
+      # pip install must not file an "endpoint failed" issue that points the
+      # maintainer at constants.py.
+      if: failure() && steps.healthcheck.outcome == 'failure'
       uses: actions/github-script@v7
       with:
         script: |

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,66 @@
+name: Endpoint Healthcheck
+
+# Proactively verifies that the external pages/files the plugin depends on are
+# still live, so a retired/moved URL (e.g. Mubi's old login page returning 404)
+# is caught here instead of via a user bug report.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: pip install requests
+
+    - name: Run endpoint healthcheck
+      run: python scripts/healthcheck.py
+
+    - name: Notify on Failure
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+          const title = `🚨 Endpoint Healthcheck Failed`;
+
+          // De-duplicate: only open a new issue if one isn't already open.
+          const existing = await github.rest.issues.listForRepo({
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100,
+          });
+          const already = existing.data.find(
+            (i) => !i.pull_request && i.title === title
+          );
+
+          const body = `One or more external endpoints the plugin depends on failed the healthcheck.\n\n[View Run logs](${run_url})\n\nA URL the plugin hardcodes (Mubi login/web page or the catalog data file) may have moved or been retired. Check the run logs for which URL failed and update \`repo/plugin_video_mubi/resources/lib/constants.py\`.`;
+
+          if (already) {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: already.number,
+              body: `Still failing as of ${new Date().toISOString()}.\n\n[View Run logs](${run_url})`,
+            });
+          } else {
+            await github.rest.issues.create({ owner, repo, title, body });
+          }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Never edit `v1_schema.json` alone. Use `/schema-change` (schema + test + models 
 - 17 tests are skipped citing `os.startfile` (Windows-only). Resolve them; do not add more skips.
 - The release workflow's `sed` produced nested `<news>` tags in v27. Edit XML with a parser, not `sed`.
 - A redirect's `Location` is not proof its target exists. mubi.com 301s `/activate`, `/tv/activate` and the retired `/android` alike to `/tv/<path>`, which then 404s. Follow the chain and check the final status before baselining a URL.
+- Notify-on-failure steps gate on `steps.<id>.outcome == 'failure'`, not bare `failure()`, or a broken `pip install` files an "endpoint failed" issue.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Never edit `v1_schema.json` alone. Use `/schema-change` (schema + test + models 
 - `xbmc.translatePath` is deprecated → `xbmcvfs`.
 - 17 tests are skipped citing `os.startfile` (Windows-only). Resolve them; do not add more skips.
 - The release workflow's `sed` produced nested `<news>` tags in v27. Edit XML with a parser, not `sed`.
+- A redirect's `Location` is not proof its target exists. mubi.com 301s `/activate`, `/tv/activate` and the retired `/android` alike to `/tv/<path>`, which then 404s. Follow the chain and check the final status before baselining a URL.
 
 ## Skills
 

--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -83,15 +83,14 @@ HEALTHCHECK_URLS = [
 
 # Activation-URL drift canary.
 #
-# `https://mubi.com/activate` is Mubi's server-side pointer to wherever device
-# activation currently lives: it permanently (301) redirects to the real path.
-# Today that first hop is `/tv/activate`. Watching *that Location header* is an
-# authoritative early signal that Mubi moved the activation page (as it did when
-# it retired /android): the redirect target changes before/independently of our
-# hardcoded MUBI_LOGIN_ACTIVATION_URL breaking, and it names the new path.
+# scripts/healthcheck.py follows MUBI_LOGIN_ACTIVATION_URL's redirect chain (the
+# page the user is told to open) and requires that it lands on a successful
+# status with a final path ending in the suffix below. Mubi prefixes a locale
+# (/tv -> /en/tv), so only the suffix is compared: a different locale on the CI
+# runner is not drift, while a move to e.g. /connect/device is, and the failure
+# message names the new path.
 #
-# The healthcheck reads the first-hop Location (redirects OFF) and compares its
-# path to the baseline below; a mismatch means "review the login URL". Only the
-# path is compared, so Mubi returning an absolute vs relative Location is fine.
-MUBI_ACTIVATION_PROBE_URL = "https://mubi.com/activate"
-MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH = "/tv/activate"
+# Do NOT baseline on a first-hop Location header: mubi.com 301s /activate,
+# /tv/activate and the retired /android alike to /tv/<path>, and those then
+# 404. That is a legacy rewrite rule, not a pointer to the activation page.
+MUBI_ACTIVATION_EXPECTED_PATH_SUFFIX = "/tv"

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -40,8 +40,8 @@ _constants = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_constants)
 
 HEALTHCHECK_URLS = _constants.HEALTHCHECK_URLS
-ACTIVATION_PROBE_URL = _constants.MUBI_ACTIVATION_PROBE_URL
-ACTIVATION_EXPECTED_REDIRECT_PATH = _constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH
+ACTIVATION_URL = _constants.MUBI_LOGIN_ACTIVATION_URL
+ACTIVATION_EXPECTED_PATH_SUFFIX = _constants.MUBI_ACTIVATION_EXPECTED_PATH_SUFFIX
 
 # A real browser UA; some sites reject the default requests UA with a 403.
 USER_AGENT = (
@@ -69,42 +69,44 @@ def check(url):
     return False, f"HTTP {resp.status_code}"
 
 
-def check_activation_redirect():
+def check_activation_page():
     """Drift canary for the device-activation URL.
 
-    `MUBI_ACTIVATION_PROBE_URL` (/activate) is Mubi's own permanent redirect to
-    wherever activation currently lives. We read that first-hop Location WITHOUT
-    following it and compare its path to the expected baseline. A mismatch is the
-    early signal that Mubi moved the activation page (as with /android) -- it
-    names the new path and can fire while the hardcoded login URL still 200s.
+    Follows `MUBI_LOGIN_ACTIVATION_URL`'s redirect chain -- the page the user is
+    told to open -- and judges where it *lands*: the final status must be
+    successful and the final path must end in `ACTIVATION_EXPECTED_PATH_SUFFIX`.
+    Mubi prefixes a locale (/tv -> /en/tv), so only the suffix is compared; a
+    move to e.g. /connect/device is reported by name.
+
+    Deliberately not a first-hop Location check: mubi.com 301s /activate,
+    /tv/activate and the retired /android alike to /tv/<path>, which then 404s.
+    That is a legacy rewrite rule, not a pointer to the activation page, and a
+    baseline built on it reports "healthy" for a dead target.
 
     Return (ok: bool, detail: str).
     """
     try:
         resp = requests.get(
-            ACTIVATION_PROBE_URL,
+            ACTIVATION_URL,
             headers={"User-Agent": USER_AGENT},
             timeout=TIMEOUT,
-            allow_redirects=False,
+            allow_redirects=True,
         )
     except requests.RequestException as exc:
         return False, f"unreachable: {exc.__class__.__name__}: {exc}"
 
-    if not (300 <= resp.status_code < 400):
+    final_path = urlsplit(resp.url).path
+    if resp.status_code >= 400:
         return False, (
-            f"expected a redirect to {ACTIVATION_EXPECTED_REDIRECT_PATH!r}, "
-            f"got HTTP {resp.status_code} (Mubi changed activation behaviour)"
+            f"activation page {ACTIVATION_URL} ends at {final_path!r} with "
+            f"HTTP {resp.status_code} -- update MUBI_LOGIN_ACTIVATION_URL in constants.py"
         )
-
-    location = resp.headers.get("Location", "")
-    # Compare only the path so an absolute vs relative Location doesn't matter.
-    actual_path = urlsplit(location).path
-    if actual_path == ACTIVATION_EXPECTED_REDIRECT_PATH:
-        return True, f"HTTP {resp.status_code} -> {actual_path}"
+    if final_path.rstrip("/").endswith(ACTIVATION_EXPECTED_PATH_SUFFIX):
+        return True, f"HTTP {resp.status_code} -> {final_path}"
     return False, (
-        f"activation URL DRIFTED: /activate now redirects to {actual_path!r} "
-        f"(baseline {ACTIVATION_EXPECTED_REDIRECT_PATH!r}) -- update "
-        f"MUBI_LOGIN_ACTIVATION_URL / the baseline in constants.py"
+        f"activation URL DRIFTED: {ACTIVATION_URL} now resolves to {final_path!r} "
+        f"(expected a path ending in {ACTIVATION_EXPECTED_PATH_SUFFIX!r}) -- update "
+        f"MUBI_LOGIN_ACTIVATION_URL / the suffix in constants.py"
     )
 
 
@@ -119,11 +121,11 @@ def main():
             failures.append((url, detail))
 
     # Drift canary (separate from the plain 200 checks above).
-    ok, detail = check_activation_redirect()
+    ok, detail = check_activation_page()
     symbol = "OK  " if ok else "FAIL"
-    print(f"  [{symbol}] activation-redirect canary  ({detail})")
+    print(f"  [{symbol}] activation-page canary  ({detail})")
     if not ok:
-        failures.append((ACTIVATION_PROBE_URL, detail))
+        failures.append((ACTIVATION_URL, detail))
 
     total = len(HEALTHCHECK_URLS) + 1
     print()

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+External-endpoint healthcheck.
+
+Requests every URL the plugin depends on (see
+`repo/plugin_video_mubi/resources/lib/constants.py::HEALTHCHECK_URLS`) and fails
+if any returns an unsuccessful HTTP status or is unreachable.
+
+This exists because a third party retiring/moving a page it hosts (e.g. Mubi
+retiring https://mubi.com/android -> 404, which silently broke plugin login) is
+invisible to unit tests: the hardcoded string is still "correct", only the
+remote server changed. Only a live request against the real URL catches it.
+
+Run locally:   python scripts/healthcheck.py
+Exit code 0 = all healthy, 1 = one or more failed.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import requests
+
+# Import the constants module directly by path so we don't pull in the Kodi
+# addon package (which imports `xbmc` and friends unavailable in CI).
+_CONSTANTS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "repo"
+    / "plugin_video_mubi"
+    / "resources"
+    / "lib"
+    / "constants.py"
+)
+
+_spec = importlib.util.spec_from_file_location("mubi_constants", _CONSTANTS_PATH)
+_constants = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_constants)
+
+HEALTHCHECK_URLS = _constants.HEALTHCHECK_URLS
+ACTIVATION_PROBE_URL = _constants.MUBI_ACTIVATION_PROBE_URL
+ACTIVATION_EXPECTED_REDIRECT_PATH = _constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH
+
+# A real browser UA; some sites reject the default requests UA with a 403.
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) "
+    "Gecko/20100101 Firefox/125.0"
+)
+TIMEOUT = 20
+
+
+def check(url):
+    """Return (ok: bool, detail: str) for a single URL."""
+    try:
+        resp = requests.get(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            timeout=TIMEOUT,
+            allow_redirects=True,
+        )
+    except requests.RequestException as exc:
+        return False, f"unreachable: {exc.__class__.__name__}: {exc}"
+
+    # 2xx and 3xx are healthy; 4xx/5xx mean the page is gone or broken.
+    if resp.status_code < 400:
+        return True, f"HTTP {resp.status_code}"
+    return False, f"HTTP {resp.status_code}"
+
+
+def check_activation_redirect():
+    """Drift canary for the device-activation URL.
+
+    `MUBI_ACTIVATION_PROBE_URL` (/activate) is Mubi's own permanent redirect to
+    wherever activation currently lives. We read that first-hop Location WITHOUT
+    following it and compare its path to the expected baseline. A mismatch is the
+    early signal that Mubi moved the activation page (as with /android) -- it
+    names the new path and can fire while the hardcoded login URL still 200s.
+
+    Return (ok: bool, detail: str).
+    """
+    try:
+        resp = requests.get(
+            ACTIVATION_PROBE_URL,
+            headers={"User-Agent": USER_AGENT},
+            timeout=TIMEOUT,
+            allow_redirects=False,
+        )
+    except requests.RequestException as exc:
+        return False, f"unreachable: {exc.__class__.__name__}: {exc}"
+
+    if not (300 <= resp.status_code < 400):
+        return False, (
+            f"expected a redirect to {ACTIVATION_EXPECTED_REDIRECT_PATH!r}, "
+            f"got HTTP {resp.status_code} (Mubi changed activation behaviour)"
+        )
+
+    location = resp.headers.get("Location", "")
+    # Compare only the path so an absolute vs relative Location doesn't matter.
+    actual_path = urlsplit(location).path
+    if actual_path == ACTIVATION_EXPECTED_REDIRECT_PATH:
+        return True, f"HTTP {resp.status_code} -> {actual_path}"
+    return False, (
+        f"activation URL DRIFTED: /activate now redirects to {actual_path!r} "
+        f"(baseline {ACTIVATION_EXPECTED_REDIRECT_PATH!r}) -- update "
+        f"MUBI_LOGIN_ACTIVATION_URL / the baseline in constants.py"
+    )
+
+
+def main():
+    print("Checking external endpoints the plugin depends on...\n")
+    failures = []
+    for url in HEALTHCHECK_URLS:
+        ok, detail = check(url)
+        symbol = "OK  " if ok else "FAIL"
+        print(f"  [{symbol}] {url}  ({detail})")
+        if not ok:
+            failures.append((url, detail))
+
+    # Drift canary (separate from the plain 200 checks above).
+    ok, detail = check_activation_redirect()
+    symbol = "OK  " if ok else "FAIL"
+    print(f"  [{symbol}] activation-redirect canary  ({detail})")
+    if not ok:
+        failures.append((ACTIVATION_PROBE_URL, detail))
+
+    total = len(HEALTHCHECK_URLS) + 1
+    print()
+    if failures:
+        print(f"{len(failures)} of {total} check(s) FAILED:")
+        for url, detail in failures:
+            print(f"  - {url}: {detail}")
+        return 1
+
+    print(f"All {total} checks healthy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/plugin_video_mubi/test_url_constants.py
+++ b/tests/plugin_video_mubi/test_url_constants.py
@@ -19,7 +19,6 @@ class TestUrlConstants:
             "TMDB_API_URL",
             "OMDB_API_URL",
             "IMDB_TITLE_URL_TEMPLATE",
-            "MUBI_ACTIVATION_PROBE_URL",
         ):
             value = getattr(constants, name)
             assert value.startswith("https://"), f"{name} must be https"
@@ -57,10 +56,16 @@ class TestUrlConstants:
 
         assert data_source.GithubDataSource.GITHUB_URL == constants.CATALOG_FILMS_URL
 
-    def test_activation_drift_canary_baselines_present(self):
-        assert constants.MUBI_ACTIVATION_PROBE_URL.startswith("https://")
-        # The expected redirect target is compared as a path, so it must be one.
-        assert constants.MUBI_ACTIVATION_EXPECTED_REDIRECT_PATH.startswith("/")
+    def test_activation_canary_suffix_matches_the_login_url(self):
+        # scripts/healthcheck.py follows MUBI_LOGIN_ACTIVATION_URL's redirects and
+        # requires the final path to end in this suffix, so the suffix must be a
+        # path fragment and the login URL itself must satisfy it.
+        from urllib.parse import urlsplit
+
+        suffix = constants.MUBI_ACTIVATION_EXPECTED_PATH_SUFFIX
+        assert suffix.startswith("/")
+        login_path = urlsplit(constants.MUBI_LOGIN_ACTIVATION_URL).path.rstrip("/")
+        assert login_path.endswith(suffix)
 
 
 class TestNoUrlLiteralsOutsideConstants:

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/healthcheck.py status classification."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "healthcheck.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("healthcheck", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+healthcheck = _load()
+
+
+def _response(status, headers=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = headers or {}
+    return resp
+
+
+class TestCheck:
+    @pytest.mark.parametrize("status", [200, 201, 301, 302, 399])
+    def test_success_and_redirect_are_healthy(self, status):
+        with patch.object(healthcheck.requests, "get", return_value=_response(status)):
+            ok, detail = healthcheck.check("https://example.com")
+        assert ok is True
+        assert str(status) in detail
+
+    @pytest.mark.parametrize("status", [400, 404, 410, 500, 503])
+    def test_client_and_server_errors_fail(self, status):
+        with patch.object(healthcheck.requests, "get", return_value=_response(status)):
+            ok, detail = healthcheck.check("https://example.com")
+        assert ok is False
+        assert str(status) in detail
+
+    def test_unreachable_host_fails_gracefully(self):
+        with patch.object(
+            healthcheck.requests,
+            "get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            ok, detail = healthcheck.check("https://nope.invalid")
+        assert ok is False
+        assert "unreachable" in detail
+
+    def test_main_returns_nonzero_when_any_fail(self):
+        with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a", "https://b"]):
+            with patch.object(
+                healthcheck,
+                "check",
+                side_effect=[(True, "HTTP 200"), (False, "HTTP 404")],
+            ):
+                with patch.object(
+                    healthcheck,
+                    "check_activation_redirect",
+                    return_value=(True, "HTTP 301 -> /tv/activate"),
+                ):
+                    assert healthcheck.main() == 1
+
+    def test_main_returns_zero_when_all_pass(self):
+        with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a"]):
+            with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
+                with patch.object(
+                    healthcheck,
+                    "check_activation_redirect",
+                    return_value=(True, "HTTP 301 -> /tv/activate"),
+                ):
+                    assert healthcheck.main() == 0
+
+
+class TestActivationRedirectCanary:
+    def test_matching_relative_location_is_healthy(self):
+        with patch.object(
+            healthcheck,
+            "ACTIVATION_EXPECTED_REDIRECT_PATH",
+            "/tv/activate",
+        ):
+            with patch.object(
+                healthcheck.requests,
+                "get",
+                return_value=_response(301, {"Location": "/tv/activate"}),
+            ):
+                ok, detail = healthcheck.check_activation_redirect()
+        assert ok is True
+        assert "/tv/activate" in detail
+
+    def test_absolute_location_compares_by_path(self):
+        with patch.object(
+            healthcheck, "ACTIVATION_EXPECTED_REDIRECT_PATH", "/tv/activate"
+        ):
+            with patch.object(
+                healthcheck.requests,
+                "get",
+                return_value=_response(
+                    301, {"Location": "https://mubi.com/tv/activate"}
+                ),
+            ):
+                ok, _ = healthcheck.check_activation_redirect()
+        assert ok is True
+
+    def test_drifted_location_fails_and_names_new_path(self):
+        with patch.object(
+            healthcheck, "ACTIVATION_EXPECTED_REDIRECT_PATH", "/tv/activate"
+        ):
+            with patch.object(
+                healthcheck.requests,
+                "get",
+                return_value=_response(301, {"Location": "/connect/device"}),
+            ):
+                ok, detail = healthcheck.check_activation_redirect()
+        assert ok is False
+        assert "DRIFTED" in detail
+        assert "/connect/device" in detail  # names the new path
+
+    def test_non_redirect_status_fails(self):
+        with patch.object(
+            healthcheck.requests, "get", return_value=_response(200, {})
+        ):
+            ok, detail = healthcheck.check_activation_redirect()
+        assert ok is False
+        assert "200" in detail
+
+    def test_unreachable_fails_gracefully(self):
+        with patch.object(
+            healthcheck.requests,
+            "get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            ok, detail = healthcheck.check_activation_redirect()
+        assert ok is False
+        assert "unreachable" in detail
+
+    def test_main_fails_when_canary_drifts(self):
+        with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a"]):
+            with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
+                with patch.object(
+                    healthcheck,
+                    "check_activation_redirect",
+                    return_value=(False, "activation URL DRIFTED"),
+                ):
+                    assert healthcheck.main() == 1

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Tests for scripts/healthcheck.py status classification."""
+"""Tests for scripts/healthcheck.py: status classification and the
+activation-page drift canary."""
 
 import importlib.util
 from pathlib import Path
@@ -21,9 +22,11 @@ def _load():
 healthcheck = _load()
 
 
-def _response(status, headers=None):
+def _response(status, url="https://example.com", headers=None):
+    """A requests.Response stand-in. `url` is the final URL after redirects."""
     resp = MagicMock()
     resp.status_code = status
+    resp.url = url
     resp.headers = headers or {}
     return resp
 
@@ -53,6 +56,8 @@ class TestCheck:
         assert ok is False
         assert "unreachable" in detail
 
+
+class TestMain:
     def test_main_returns_nonzero_when_any_fail(self):
         with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a", "https://b"]):
             with patch.object(
@@ -62,8 +67,8 @@ class TestCheck:
             ):
                 with patch.object(
                     healthcheck,
-                    "check_activation_redirect",
-                    return_value=(True, "HTTP 301 -> /tv/activate"),
+                    "check_activation_page",
+                    return_value=(True, "HTTP 200 -> /en/tv"),
                 ):
                     assert healthcheck.main() == 1
 
@@ -72,80 +77,72 @@ class TestCheck:
             with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
                 with patch.object(
                     healthcheck,
-                    "check_activation_redirect",
-                    return_value=(True, "HTTP 301 -> /tv/activate"),
+                    "check_activation_page",
+                    return_value=(True, "HTTP 200 -> /en/tv"),
                 ):
                     assert healthcheck.main() == 0
-
-
-class TestActivationRedirectCanary:
-    def test_matching_relative_location_is_healthy(self):
-        with patch.object(
-            healthcheck,
-            "ACTIVATION_EXPECTED_REDIRECT_PATH",
-            "/tv/activate",
-        ):
-            with patch.object(
-                healthcheck.requests,
-                "get",
-                return_value=_response(301, {"Location": "/tv/activate"}),
-            ):
-                ok, detail = healthcheck.check_activation_redirect()
-        assert ok is True
-        assert "/tv/activate" in detail
-
-    def test_absolute_location_compares_by_path(self):
-        with patch.object(
-            healthcheck, "ACTIVATION_EXPECTED_REDIRECT_PATH", "/tv/activate"
-        ):
-            with patch.object(
-                healthcheck.requests,
-                "get",
-                return_value=_response(
-                    301, {"Location": "https://mubi.com/tv/activate"}
-                ),
-            ):
-                ok, _ = healthcheck.check_activation_redirect()
-        assert ok is True
-
-    def test_drifted_location_fails_and_names_new_path(self):
-        with patch.object(
-            healthcheck, "ACTIVATION_EXPECTED_REDIRECT_PATH", "/tv/activate"
-        ):
-            with patch.object(
-                healthcheck.requests,
-                "get",
-                return_value=_response(301, {"Location": "/connect/device"}),
-            ):
-                ok, detail = healthcheck.check_activation_redirect()
-        assert ok is False
-        assert "DRIFTED" in detail
-        assert "/connect/device" in detail  # names the new path
-
-    def test_non_redirect_status_fails(self):
-        with patch.object(
-            healthcheck.requests, "get", return_value=_response(200, {})
-        ):
-            ok, detail = healthcheck.check_activation_redirect()
-        assert ok is False
-        assert "200" in detail
-
-    def test_unreachable_fails_gracefully(self):
-        with patch.object(
-            healthcheck.requests,
-            "get",
-            side_effect=requests.ConnectionError("boom"),
-        ):
-            ok, detail = healthcheck.check_activation_redirect()
-        assert ok is False
-        assert "unreachable" in detail
 
     def test_main_fails_when_canary_drifts(self):
         with patch.object(healthcheck, "HEALTHCHECK_URLS", ["https://a"]):
             with patch.object(healthcheck, "check", return_value=(True, "HTTP 200")):
                 with patch.object(
                     healthcheck,
-                    "check_activation_redirect",
+                    "check_activation_page",
                     return_value=(False, "activation URL DRIFTED"),
                 ):
                     assert healthcheck.main() == 1
+
+
+class TestActivationPageCanary:
+    """The canary follows MUBI_LOGIN_ACTIVATION_URL's redirect chain and judges
+    where it *lands*, never a first-hop Location (hostile audit of PR 58, F1:
+    mubi.com 301s /activate -> /tv/activate, which itself 404s)."""
+
+    def _run(self, response, suffix="/tv"):
+        with patch.object(healthcheck, "ACTIVATION_URL", "https://mubi.com/tv"):
+            with patch.object(healthcheck, "ACTIVATION_EXPECTED_PATH_SUFFIX", suffix):
+                with patch.object(healthcheck.requests, "get", **response) as get:
+                    result = healthcheck.check_activation_page()
+        return result, get
+
+    def test_locale_prefixed_final_page_is_healthy(self):
+        (ok, detail), _ = self._run({"return_value": _response(200, "https://mubi.com/en/tv")})
+        assert ok is True
+        assert "/en/tv" in detail
+
+    def test_other_locale_prefix_is_not_drift(self):
+        (ok, _), _ = self._run({"return_value": _response(200, "https://mubi.com/de/tv")})
+        assert ok is True
+
+    def test_trailing_slash_is_not_drift(self):
+        (ok, _), _ = self._run({"return_value": _response(200, "https://mubi.com/en/tv/")})
+        assert ok is True
+
+    def test_drifted_final_path_fails_and_names_new_path(self):
+        (ok, detail), _ = self._run(
+            {"return_value": _response(200, "https://mubi.com/connect/device")}
+        )
+        assert ok is False
+        assert "DRIFTED" in detail
+        assert "/connect/device" in detail  # names the new path
+
+    def test_canary_fails_when_followed_target_is_not_2xx(self):
+        # Regression for F1: /activate -> 301 /tv/activate -> ... -> 404. A chain
+        # that ends on an error page is unhealthy even if the path looks right.
+        (ok, detail), _ = self._run(
+            {"return_value": _response(404, "https://mubi.com/en/tv/tv/activate")}
+        )
+        assert ok is False
+        assert "404" in detail
+
+    def test_unreachable_fails_gracefully(self):
+        (ok, detail), _ = self._run({"side_effect": requests.ConnectionError("boom")})
+        assert ok is False
+        assert "unreachable" in detail
+
+    def test_canary_probes_the_url_the_user_is_shown(self):
+        # The canary must check the login URL the plugin displays, not a probe
+        # URL whose redirect happens to look authoritative.
+        (ok, _), get = self._run({"return_value": _response(200, "https://mubi.com/en/tv")})
+        assert get.call_args.args[0] == "https://mubi.com/tv"
+        assert healthcheck.ACTIVATION_URL == healthcheck._constants.MUBI_LOGIN_ACTIVATION_URL

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -146,3 +146,29 @@ class TestActivationPageCanary:
         (ok, _), get = self._run({"return_value": _response(200, "https://mubi.com/en/tv")})
         assert get.call_args.args[0] == "https://mubi.com/tv"
         assert healthcheck.ACTIVATION_URL == healthcheck._constants.MUBI_LOGIN_ACTIVATION_URL
+
+
+class TestRequestOptions:
+    """Hostile audit of PR 58, F2: three mutations escaped the suite -- dropping
+    the timeout (a hung host then stalls the job until GitHub's 6 h default),
+    dropping the browser User-Agent (some hosts answer 403 to python-requests),
+    and flipping allow_redirects on the canary. Pin all three."""
+
+    def test_check_uses_timeout_and_browser_user_agent(self):
+        with patch.object(healthcheck.requests, "get", return_value=_response(200)) as get:
+            healthcheck.check("https://example.com")
+        kwargs = get.call_args.kwargs
+        assert kwargs["timeout"] == healthcheck.TIMEOUT
+        assert healthcheck.TIMEOUT > 0
+        assert kwargs["headers"]["User-Agent"].startswith("Mozilla/")
+        assert kwargs["allow_redirects"] is True
+
+    def test_canary_follows_redirect_chain_with_timeout_and_browser_user_agent(self):
+        with patch.object(
+            healthcheck.requests, "get", return_value=_response(200, "https://mubi.com/en/tv")
+        ) as get:
+            healthcheck.check_activation_page()
+        kwargs = get.call_args.kwargs
+        assert kwargs["allow_redirects"] is True
+        assert kwargs["timeout"] == healthcheck.TIMEOUT
+        assert kwargs["headers"]["User-Agent"].startswith("Mozilla/")


### PR DESCRIPTION
## What & why (backend / CI only)

Split out of #46 — this is the **backend/CI half** (`scripts/`, `.github/workflows/`, `tests/test_healthcheck.py`). It has **no plugin runtime changes** (it does swap two canary constants in `constants.py`; see below).

> ⚠️ **Stacked on #57** — depends on the `constants.py` introduced there. Base branch is `refactor/centralize-urls`; merge that first, then this retargets to `main`.

A hardcoded external page being retired (Mubi's login URL → 404) is invisible to unit tests and only surfaced via a user bug report. This adds:

- `scripts/healthcheck.py` — daily liveness check of the URLs the plugin depends on (from `constants.HEALTHCHECK_URLS`); fails on non-2xx/3xx or unreachable.
- **Activation-page drift canary** — follows `MUBI_LOGIN_ACTIVATION_URL` (`https://mubi.com/tv`, the page the user is told to open) through its redirect chain and checks **where it lands**: the final response must be <400 and its path must end in `/tv` (`MUBI_ACTIVATION_EXPECTED_PATH_SUFFIX`). Mubi prefixes a locale (`/tv` → `/en/tv`), so only the suffix is compared — a different locale on the CI runner is not drift, while a move to e.g. `/connect/device` is reported **by name**.
- `.github/workflows/healthcheck.yml` — daily cron + manual dispatch, notify-on-failure that **de-duplicates** (a persistent outage comments on the open issue instead of opening a new one each day) and is **gated on the check step's own outcome**, so a broken checkout / `pip install` doesn't file a misleading "endpoint failed" issue.

Excluded from the strict check: the API base (`api.mubi.com/` 404s on a bare GET), the DRM endpoint (needs authenticated POSTs), and `ipapi.co` (bot-gated: 403 to browser UAs, 200 to python-requests).

### Why not a first-hop redirect canary

The first draft baselined on the first-hop `Location` of `https://mubi.com/activate` and expected `/tv/activate`. A hostile audit caught that as a false signal: `mubi.com` 301s `/activate`, `/tv/activate` **and the retired `/android`** alike to `/tv/<path>`, and that target then 404s (`/tv/activate` → `/tv/tv/activate` → `/en/tv/tv/activate` = 404). That 301 is a legacy `/x → /tv/x` rewrite rule, not a pointer to the activation page — so the old canary reported healthy while pointing at a dead page and could not detect the drift it was built for. The canary now follows the chain and judges the landing page instead.

### Why no VPN (unlike the sync workflows)

The sync jobs tunnel through ProtonVPN because Mubi's catalogue API is geo-specific and scraped per country. The healthcheck only asks "is this page alive", and plugin users are worldwide, so a plain GitHub runner is a representative user. Adding the VPN would import the `continue-on-error` + `exit 1` pattern, four secrets, and a second failure mode for no gain. Revisit only if the first scheduled runs show 403/429 from GitHub's IP ranges.

## Verification
- Full suite: **741 passed, 17 skipped**.
- Ran `scripts/healthcheck.py` live: 8 endpoints 2xx/3xx + canary `HTTP 200 → /en/tv`.
- `test_healthcheck.py` covers status classification, the redirect-chain canary (incl. the `/activate → 404` regression and pinned request options), all mocked — no network.
