### PR TITLE
fix: drop ifconfig.co from HEALTHCHECK_URLS (Cloudflare 403s CI IPs)

### DIFF
--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -68,14 +68,20 @@ CATALOG_FILMS_URL = (
 # authenticated call. The DRM license endpoint is likewise excluded (it only
 # responds to authenticated license POSTs).
 #
-# ipapi.co is excluded: it answers 403 to browser User-Agents and 200 to
-# python-requests, i.e. it is bot-gated and would produce false alarms.
+# Two of the four GEOIP_COUNTRY_URLS are deliberately NOT healthchecked because
+# they are bot-gated and would fire false alarms while still being fine for real
+# (residential) plugin users:
+#   - ipapi.co answers 403 to browser User-Agents and 200 to python-requests.
+#   - ifconfig.co is Cloudflare-fronted and 403s datacenter IPs (the GitHub
+#     Actions runner) while returning 200 for residential IPs. Observed live:
+#     issue #62, run 33742252948 -> HTTP 403 from the runner, 200 from a laptop.
+# geojs.io and ipinfo.io answer a bare GET with a country code from any IP, so
+# they stand in for the fallback chain's liveness.
 HEALTHCHECK_URLS = [
     MUBI_WEB_URL,
     MUBI_LOGIN_ACTIVATION_URL,
     CATALOG_FILMS_URL,
     "https://get.geojs.io/v1/ip/country",
-    "https://ifconfig.co/country-iso",
     "https://ipinfo.io/country",
     TMDB_API_URL,  # bare GET -> 204
     OMDB_API_URL,  # bare GET -> 200 (JSON error body, no key needed)

--- a/tests/plugin_video_mubi/test_url_constants.py
+++ b/tests/plugin_video_mubi/test_url_constants.py
@@ -51,6 +51,24 @@ class TestUrlConstants:
         # api.mubi.com/ returns 404 on a bare GET, so it must not be strict-checked.
         assert constants.MUBI_API_URL not in constants.HEALTHCHECK_URLS
 
+    def test_healthcheck_excludes_bot_gated_geoip_services(self):
+        # ipapi.co (403 to browser UAs) and ifconfig.co (Cloudflare 403 to
+        # datacenter IPs, e.g. the CI runner -- issue #62) 403 in CI while
+        # serving real residential users, so they are runtime fallbacks but must
+        # not be strict-checked, or the daily job false-alarms.
+        assert "https://ipapi.co/country/" not in constants.HEALTHCHECK_URLS
+        assert "https://ifconfig.co/country-iso" not in constants.HEALTHCHECK_URLS
+        # ...but they remain in the plugin's runtime fallback chain.
+        assert "https://ipapi.co/country/" in constants.GEOIP_COUNTRY_URLS
+        assert "https://ifconfig.co/country-iso" in constants.GEOIP_COUNTRY_URLS
+
+    def test_healthchecked_geoip_services_answer_from_any_ip(self):
+        # The two geo services that DO stay in the healthcheck must be the
+        # IP-agnostic ones; keep at least one so the fallback chain has coverage.
+        checked = [u for u in constants.GEOIP_COUNTRY_URLS if u in constants.HEALTHCHECK_URLS]
+        assert "https://get.geojs.io/v1/ip/country" in checked
+        assert "https://ipinfo.io/country" in checked
+
     def test_data_source_uses_catalog_constant(self):
         from resources.lib import data_source
 


### PR DESCRIPTION
## What & why

The first live healthcheck run on `main` failed and filed #62. Root cause: **`https://ifconfig.co/country-iso` returns HTTP 403 from the GitHub Actions runner.** It is Cloudflare-fronted and bot-blocks datacenter IP ranges, while returning 200 for residential IPs.

Verified:
- Run [33742252948](https://github.com/kubi2021/plugin.video.mubi/actions/runs/33742252948): `[FAIL] https://ifconfig.co/country-iso (HTTP 403)`, every other check OK.
- Same URL, same browser UA, from a laptop: `200` ×3.

So the endpoint is **not retired** — it is unverifiable from CI. Strict-checking it makes the daily job a false-alarm generator that comment-spams #62.

This is the same class as `ipapi.co`, which the module already excludes. `ifconfig.co` stays in `GEOIP_COUNTRY_URLS` (a fine fallback for real users) but leaves `HEALTHCHECK_URLS`. `geojs.io` and `ipinfo.io` stay checked, so the geo-IP fallback chain keeps liveness coverage.

Everything else the run proved out: the redirect-chain canary reported `HTTP 200 -> /en/tv`, and the notifier gating worked (only the check step failing triggered the issue).

## Verification
- `scripts/healthcheck.py` live: **All 8 checks healthy.**
- Full suite: **743 passed, 17 skipped.**
- New regression tests pin both bot-gated services out of `HEALTHCHECK_URLS` and into `GEOIP_COUNTRY_URLS`.

Closes #62 once the next run is green.
