### PR TITLE
docs: sweep dead README links, stale country count, split user vs contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ This project is a personal endeavour I work on in my free time. As I am not a pr
 
 If you are looking for a simple way of browsing the MUBI catalogue without integrating with the Kodi library, another extension does exactly this: [mtr81/kodi_addons](https://github.com/mtr81/kodi_addons).
 
+> **Want to contribute?** Development, testing, release, and backend documentation lives in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
+
 ## Features
 
 - 🎬 **Full MUBI catalogue** — Fetches all movies with ratings and descriptions, seamlessly integrated into your Kodi library
-- 🌍 **Worldwide sync** — Access MUBI's entire global catalogue (~2000 films) with smart optimization that syncs from only ~23 countries instead of 248, balancing coverage with speed
+- 🌍 **Worldwide catalogue** — Access MUBI's entire global catalogue (~2000 films). **Fast Sync** (beta) downloads a pre-computed catalogue in seconds; the classic sync fetches directly from MUBI across a small curated set of countries
 - 🛡️ **Rich metadata** — Finds IMDb matches so Kodi scrapers can fetch cast, ratings, posters, and more
 - 🍿 **Optimal quality** — Automatically selects best stream quality for movies and trailers
 - 📺 **Native playback** — Movies play directly in Kodi with Mubi subtitles and multiple audio streams
@@ -23,7 +25,7 @@ If you are looking for a simple way of browsing the MUBI catalogue without integ
 - 🏆 **Ratings & advisories** — MPAA ratings and content warnings for informed viewing
 - 🔖 **Watchlist sync** — Your MUBI watchlist accessible directly from Kodi
 - 🈯 **Multi-language** — Titles and descriptions in languages supported by MUBI (configure in plugin settings)
-- � **VPN-friendly** — Detects your country via IP and suggests optimal VPN servers for geo-restricted films
+- 🛡️ **VPN-friendly** — Detects your country via IP and suggests optimal VPN servers for geo-restricted films
 - 🖥️ **Browser fallback** — Opens films in your browser when Kodi playback isn't available (tested on macOS only)
 
 ## Installation
@@ -74,152 +76,6 @@ If you are looking for a simple way of browsing the MUBI catalogue without integ
 ### Next Runs 🚀
 
 Whenever you want to **update** the local database, run the **sync** process again. The Kodi library will be automatically updated and cleaned (movies that are no longer available in Mubi will be removed from Kodi)
-
-## Contributing
-
-### Repository Structure
-
-This project uses a **Kodi repository structure** with automated release management:
-
-```
-├── repo/                           # Kodi repository files
-│   ├── plugin_video_mubi/         # Main MUBI add-on source code
-│   │   ├── addon.xml              # Add-on definition (version managed here)
-│   │   ├── addon.py               # Main entry point
-│   │   └── resources/             # Add-on resources and Python modules
-│   │       ├── settings.xml
-│   │       └── lib/               # Core Python modules
-│   ├── repository_kubi2021/       # Repository add-on definition
-│   └── zips/                      # Generated zip files (auto-created)
-├── tests/                         # Test suite
-│   ├── plugin_video_mubi/         # Tests for MUBI add-on
-│   └── repository_kubi2021/       # Tests for repository (future)
-├── docs/                          # Documentation
-├── _repo_generator.py             # Repository build script
-└── .github/workflows/             # CI/CD automation
-```
-
-### Development Workflow
-
-1. **Make Changes**: Edit files in `repo/plugin_video_mubi/`
-2. **Run Tests**: `pytest tests/`
-3. **Update Country Catalogue** Run the coverage analyzer to regenerate the country optimization data
-4. **Create PR**: Submit pull request to `main` branch
-5. **Merge PR**: Normal merge
-6. **Manual Release** (when ready): Go to Actions → "Release Plugin Update" → Run workflow:
-   - Enter release notes (user-facing description)
-   - GitHub Actions automatically:
-     - Increments version number (simple: 5 → 6)
-     - Updates `addon.xml` news section with release notes
-     - Generates repository zip files
-     - Creates GitHub release with assets
-     - Updates repository metadata
-
-### Key Files for Contributors
-
-- **Main Add-on Code**: `repo/plugin_video_mubi/`
-- **Version Management**: `repo/plugin_video_mubi/addon.xml` (line 2) - auto-updated on release
-- **Tests**: `tests/plugin_video_mubi/`
-- **Release Workflow**: `.github/workflows/auto-release.yml` - manual trigger only
-- **Release Guide**: `docs/RELEASE_MANAGEMENT.md` - detailed release process
-
-### Testing
-
-```bash
-# Run all tests
-pytest tests/
-
-# Run specific test file
-pytest tests/plugin_video_mubi/test_library.py
-
-# Run with coverage
-pytest tests/ --cov=repo/plugin_video_mubi --cov-report=term-missing
-```
-
-### Manual Repository Generation
-
-```bash
-# Generate repository files manually
-python3 _repo_generator.py
-
-# Files created in repo/zips/:
-# - plugin.video.mubi-X.zip (add-on)
-# - repository.kubi2021-2.zip (repository)
-# - addons.xml (metadata)
-# - addons.xml.md5 (checksum)
-```
-
-### Country Coverage Analyzer
-
-The worldwide sync uses a pre-computed JSON catalogue to optimize which countries to fetch. Run the analyzer to regenerate this data when MUBI's catalogue changes significantly:
-
-```bash
-cd repo/plugin_video_mubi
-
-# Fetch fresh data from MUBI API and save to JSON (requires valid MUBI session)
-python -m tools.analyze_coverage
-
-# Analyze existing JSON without re-fetching
-python -m tools.analyze_coverage --analyze-only --country CH
-```
-
-The analyzer uses a greedy set cover algorithm to find the minimum countries needed for 100% catalogue coverage. Output is saved to `resources/data/country_catalogue.json`.
-
-
-### The "Shadow Backend" 👻
-
-As of **Dec 2025**, this project uses a decoupled architecture to manage the global film catalogue. 
-
-**Concept:**
-Instead of the Kodi plugin crawling the Mubi API for every user (which is slow and error-prone), a GitHub Action runs periodically to harvest the entire catalogue. This data is compressed and pushed to an orphan branch (`database`), acting as a "CDN" for the plugin.
-
-**Benefits:**
-- ⚡ **Instant Sync:** Plugin downloads a single compressed file instead of making thousands of API calls.
-- 🛡️ **Reliability:** Scraper runs on a server, reducing rate-limiting issues for end-users.
-- 📉 **Low Bandwidth:** Tiny updates compared to full crawls.
-
-**How to Run Manually:**
-1. Go to the [Actions tab](https://github.com/kubi2021/plugin.video.mubi/actions).
-2. Select **"Update Mubi Catalog"**.
-3. Click **"Run workflow"**.
-
-**Where are the files?**
-The generated database files are stored in the **[database branch](https://github.com/kubi2021/plugin.video.mubi/tree/database)** (orphan branch).
-- **Catalogue:** [`v1/films.json.gz`](https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz)
-- **Checksum:** [`v1/films.json.gz.md5`](https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz.md5)
-
-### Versioning Policy
-
-- **Simple incremental**: 1, 2, 3, 4, 5... (no semantic versioning)
-- **Auto-managed**: Version increments automatically on PR merge
-- **Repository stable**: Repository version stays at 2, only add-on versions increment
-
-### Release Process
-
-**Manual Release Control**:
-1. **Regular Development**: Merge PRs normally (tests, docs, refactoring) - no automatic releases
-2. **When Ready to Release**:
-   - Go to **Actions** → **"Release Plugin Update"** → **"Run workflow"**
-   - Enter **release notes**: "Fixed audio detection and improved error handling"
-   - Click **"Run workflow"**
-3. **Result**: New version appears in GitHub releases, users get update notifications in Kodi
-
-**When to Release**:
-- ✅ New features for users
-- ✅ Bug fixes affecting functionality
-- ✅ Security updates
-- ❌ Test improvements, documentation, refactoring
-
-**Example Workflow**:
-```
-Week 1: Merge "Improve test coverage" → No release
-Week 1: Merge "Update README" → No release
-Week 2: Merge "Add 5.1 audio support" → Manual release v6
-Week 2: Merge "Fix login timeout" → Include in next release
-Week 3: Manual release v7 → "Audio improvements and login fixes"
-```
-
----
 
 ## Changelog
 
@@ -365,3 +221,7 @@ After adding the source manually, follow the normal steps to configure it for mo
 ---
 
 Enjoy Mubi on Kodi! 🎥🍿
+
+---
+
+_Last updated: 2026-09-03_

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+# Contributing to plugin.video.mubi
+
+This guide covers everything a contributor needs: repository layout, the development
+workflow, testing, the "Shadow Backend" that pre-computes the catalogue, and the
+release process. User-facing install and usage instructions live in the
+[README](../README.md).
+
+See also [DEVELOPMENT_PRINCIPLES.md](DEVELOPMENT_PRINCIPLES.md) for the reasoning
+behind the rules, and the top-level `CLAUDE.md` for the terse rule list.
+
+## Repository Structure
+
+This project uses a **Kodi repository structure** with automated release management:
+
+```
+├── repo/                           # Kodi repository files
+│   └── plugin_video_mubi/          # Main MUBI add-on source code
+│       ├── addon.xml               # Add-on definition (version managed here)
+│       ├── addon.py                # Main entry point
+│       └── resources/              # Add-on resources and Python modules
+│           ├── settings.xml
+│           ├── data/               # Pre-computed data (e.g. country_catalogue.json)
+│           └── lib/                # Core Python modules
+├── backend/                        # GitHub-Actions catalogue backend (Python 3.11)
+├── tests/                          # Test suite
+│   ├── plugin_video_mubi/          # Tests for the MUBI add-on
+│   ├── backend/                    # Tests for the backend pipeline
+│   ├── repository_kubi2021/        # Tests for the repository add-on
+│   └── integration/                # Integration tests
+├── docs/                           # Documentation
+├── _repo_generator.py              # Repository build script
+└── .github/workflows/              # CI/CD automation
+```
+
+## Development Workflow
+
+1. **Make Changes**: Edit files in `repo/plugin_video_mubi/` (plugin) or `backend/` (catalogue backend).
+2. **Run Tests**: `pytest tests/` (see [Testing](#testing)).
+3. **Create PR**: Submit a pull request to the `main` branch. Keep one concern per PR.
+4. **Merge PR**: Normal merge — merging does **not** cut a release.
+5. **Manual Release** (when ready): Go to Actions → "Release Plugin Update" → Run workflow:
+   - Enter release notes (user-facing description)
+   - GitHub Actions automatically:
+     - Increments the version number (simple: 5 → 6)
+     - Updates `addon.xml` news section with release notes
+     - Generates repository zip files
+     - Creates the GitHub release with assets
+     - Updates repository metadata
+
+## Key Files for Contributors
+
+- **Main Add-on Code**: `repo/plugin_video_mubi/`
+- **Version Management**: `repo/plugin_video_mubi/addon.xml` (line 2) — auto-updated on release
+- **Plugin Tests**: `tests/plugin_video_mubi/`
+- **Backend Pipeline**: `backend/` (`scraper` → `enrich_metadata` → `rating_calculator` → `generate_repo` → `validate_schema`)
+- **Schema Contract**: `backend/schemas/v1_schema.json` (CODEOWNERS-protected)
+- **Release Workflow**: `.github/workflows/auto-release.yml` — manual trigger only
+
+## Testing
+
+The test suite lives under `tests/`. See [`tests/plugin_video_mubi/README.md`](../tests/plugin_video_mubi/README.md)
+for the plugin test conventions (Kodi stubs, fixtures, mocking strategy).
+
+```bash
+# Run all tests
+pytest tests/
+
+# Run a specific test file
+pytest tests/plugin_video_mubi/test_library.py
+
+# Run with coverage (matches CI: minimum 65%)
+pytest tests/ --cov=repo/plugin_video_mubi --cov=backend \
+  --cov-config=.coveragerc --cov-report=term-missing
+```
+
+CI (`.github/workflows/test.yml`) runs the suite across Python 3.8–3.11 and enforces
+coverage ≥ 65%.
+
+## Manual Repository Generation
+
+```bash
+# Generate repository files manually
+python3 _repo_generator.py
+
+# Files created in repo/zips/:
+# - plugin.video.mubi-X.zip (add-on)
+# - repository.kubi2021-2.zip (repository)
+# - addons.xml (metadata)
+# - addons.xml.md5 (checksum)
+```
+
+## Country Coverage Data
+
+The classic (direct-API) worldwide sync uses a pre-computed JSON catalogue to decide
+which countries to fetch from. That file — `repo/plugin_video_mubi/resources/data/country_catalogue.json`
+— maps each film to the countries where it is available, and
+`resources/lib/coverage_optimizer.py` runs a greedy set-cover over it to find the
+minimum set of countries needed for full coverage, starting with the user's country.
+
+The catalogue is a **committed artifact**; there is currently no regeneration script in
+the repository. If MUBI's catalogue changes significantly and the file needs to be
+rebuilt, regenerate it and commit the result.
+
+> Note: the direct-API sync also has a small built-in fallback set,
+> `SYNC_COUNTRIES = ['CH', 'DE', 'US', 'GB', 'FR', 'JP']`, defined in
+> `resources/lib/data_source.py` and `resources/lib/mubi.py`. This is used when no
+> client country is configured. Most users are now on **Fast Sync**, which downloads
+> the whole pre-computed catalogue from the backend and does not crawl per country.
+
+## The "Shadow Backend" 👻
+
+As of **Dec 2025**, this project uses a decoupled architecture to manage the global film catalogue.
+
+**Concept:**
+Instead of the Kodi plugin crawling the Mubi API for every user (which is slow and error-prone), a GitHub Action runs periodically to harvest the entire catalogue. This data is compressed and pushed to an orphan branch (`database`), acting as a "CDN" for the plugin.
+
+**Benefits:**
+- ⚡ **Instant Sync:** Plugin downloads a single compressed file instead of making thousands of API calls.
+- 🛡️ **Reliability:** Scraper runs on a server, reducing rate-limiting issues for end-users.
+- 📉 **Low Bandwidth:** Tiny updates compared to full crawls.
+
+**How to Run Manually:**
+1. Go to the [Actions tab](https://github.com/kubi2021/plugin.video.mubi/actions).
+2. Select **"Update Mubi Catalog"**.
+3. Click **"Run workflow"**.
+
+**Where are the files?**
+The generated database files are stored in the **[database branch](https://github.com/kubi2021/plugin.video.mubi/tree/database)** (orphan branch).
+- **Catalogue:** [`v1/films.json.gz`](https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz)
+- **Checksum:** [`v1/films.json.gz.md5`](https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz.md5)
+
+For the weekly digest email pipeline, see [email_generation.md](email_generation.md).
+
+## Versioning Policy
+
+- **Simple incremental**: 1, 2, 3, 4, 5… (no semantic versioning)
+- **Auto-managed**: Version increments automatically when a release is cut
+- **Repository stable**: Repository version stays at 2, only add-on versions increment
+
+## Release Process
+
+**Manual Release Control**:
+1. **Regular Development**: Merge PRs normally (tests, docs, refactoring) — no automatic releases
+2. **When Ready to Release**:
+   - Go to **Actions** → **"Release Plugin Update"** → **"Run workflow"**
+   - Enter **release notes**: "Fixed audio detection and improved error handling"
+   - Click **"Run workflow"**
+3. **Result**: New version appears in GitHub releases, users get update notifications in Kodi
+
+**When to Release**:
+- ✅ New features for users
+- ✅ Bug fixes affecting functionality
+- ✅ Security updates
+- ❌ Test improvements, documentation, refactoring
+
+**Example Workflow**:
+```
+Week 1: Merge "Improve test coverage" → No release
+Week 1: Merge "Update README" → No release
+Week 2: Merge "Add 5.1 audio support" → Manual release v6
+Week 2: Merge "Fix login timeout" → Include in next release
+Week 3: Manual release v7 → "Audio improvements and login fixes"
+```
+
+---
+
+_Last updated: 2026-09-03_

--- a/docs/email_generation.md
+++ b/docs/email_generation.md
@@ -67,4 +67,17 @@ The email template (`weekly-digest.tsx`) is designed to read dynamic data from a
 
 > **Note**: The React component looks for `tmp/weekly_digest.json`. If this file is missing, it falls back to hardcoded sample data (e.g., "Senna").
 
-To update the email with real data, you must run the generation script that produces this JSON artifact (implementation pending integration with `generate_weekly_digest.py`).
+The generation step is fully wired into CI. The [`weekly-digest.yml`](../.github/workflows/weekly-digest.yml)
+workflow runs every Friday: it fetches `films.json.gz` from the `database` branch,
+unzips it, and runs `backend/generate_weekly_digest.py` to produce the digest artifact
+before rendering and sending the email via React Email.
+
+To reproduce it locally, run the generation script against a local `films.json`:
+
+```bash
+python3 backend/generate_weekly_digest.py --input films.json --output backend/tmp/weekly_digest.md
+```
+
+---
+
+_Last updated: 2026-09-03_

--- a/tests/plugin_video_mubi/README.md
+++ b/tests/plugin_video_mubi/README.md
@@ -53,7 +53,7 @@ pytest tests/ -v
 
 #### Coverage Report
 ```bash
-pytest tests/ --cov=resources --cov-report=term-missing --cov-fail-under=65
+pytest tests/ --cov=repo/plugin_video_mubi --cov-report=term-missing --cov-fail-under=65
 ```
 
 #### Parallel Execution
@@ -63,7 +63,7 @@ pytest tests/ -n auto
 
 #### Specific Test File
 ```bash
-pytest tests/test_film.py -v
+pytest tests/plugin_video_mubi/test_film.py -v
 ```
 
 #### Specific Test Function
@@ -75,22 +75,22 @@ pytest tests/ -k "test_film_initialization" -v
 
 #### Code Formatting
 ```bash
-python -m black resources/ tests/ addon.py
-python -m isort resources/ tests/ addon.py
+python -m black repo/plugin_video_mubi/resources/ tests/ repo/plugin_video_mubi/addon.py
+python -m isort repo/plugin_video_mubi/resources/ tests/ repo/plugin_video_mubi/addon.py
 ```
 
 #### Linting
 ```bash
-python -m flake8 resources/ tests/ addon.py
+python -m flake8 repo/plugin_video_mubi/resources/ tests/ repo/plugin_video_mubi/addon.py
 ```
 
 #### Combined Workflow
 ```bash
 # Format, lint, and test with coverage
-python -m black resources/ tests/ addon.py && \
-python -m isort resources/ tests/ addon.py && \
-python -m flake8 resources/ tests/ addon.py && \
-python -m pytest tests/ --cov=resources --cov-report=term-missing --cov-fail-under=65
+python -m black repo/plugin_video_mubi/resources/ tests/ repo/plugin_video_mubi/addon.py && \
+python -m isort repo/plugin_video_mubi/resources/ tests/ repo/plugin_video_mubi/addon.py && \
+python -m flake8 repo/plugin_video_mubi/resources/ tests/ repo/plugin_video_mubi/addon.py && \
+python -m pytest tests/ --cov=repo/plugin_video_mubi --cov-report=term-missing --cov-fail-under=65
 ```
 
 ## Test Coverage
@@ -188,7 +188,7 @@ strategy:
     python-version: [3.8, 3.9, '3.10', '3.11']
 
 # Coverage validation
-pytest tests/ --cov=resources --cov-report=term-missing --cov-fail-under=65
+pytest tests/ --cov=repo/plugin_video_mubi --cov-report=term-missing --cov-fail-under=65
 ```
 
 ### Local CI Simulation
@@ -200,7 +200,7 @@ To run the same tests locally as CI:
 pip install -r requirements-dev.txt
 
 # Run tests with coverage (same as CI)
-pytest tests/ -v --tb=short --cov=resources --cov-report=term-missing --cov-fail-under=65
+pytest tests/ -v --tb=short --cov=repo/plugin_video_mubi --cov-report=term-missing --cov-fail-under=65
 ```
 
 ## Troubleshooting
@@ -228,3 +228,7 @@ When adding new functionality:
 3. Follow existing test patterns
 4. Update this README if needed
 5. Ensure all tests pass before submitting
+
+---
+
+_Last updated: 2026-09-03_


### PR DESCRIPTION
Closes #55.

Documentation had drifted from the code and mixed user and contributor content in one long README. This is a docs-only sweep.

## Changes

**README.md — dead references removed**
- Dropped the link to `docs/RELEASE_MANAGEMENT.md` (file never existed).
- Removed the `python -m tools.analyze_coverage` reference and the "Country Coverage Analyzer" how-to (the `tools/` package does not exist).
- Replaced the "~23 countries instead of 248" feature claim with wording that matches the code (`SYNC_COUNTRIES` = 6 in `data_source.py`; Fast Sync downloads the whole pre-computed catalogue).

**README split into user vs contributor docs**
- README now holds only user-facing content: Why / Features / Installation / First run / Changelog / Troubleshooting, plus a pointer to the contributor guide.
- New **`docs/CONTRIBUTING.md`** holds Repository Structure, Development Workflow, Testing, Manual Repo Generation, the Shadow Backend, Versioning Policy, and the Release Process.
- The country-coverage explainer is rewritten honestly: `country_catalogue.json` is a committed artifact consumed by `coverage_optimizer.py`, and there is **no** regeneration script in the repo.

**`tests/plugin_video_mubi/README.md`**
- `--cov=resources` -> `--cov=repo/plugin_video_mubi` in all four places.
- Fixed the stale `resources/ tests/ addon.py` format/lint paths and the `tests/test_film.py` example path.

**`docs/email_generation.md`**
- The digest JSON step is no longer "pending integration" -- `weekly-digest.yml` already runs `backend/generate_weekly_digest.py`. Documented the CI step and a local repro command.

**Housekeeping**
- Added "Last updated" lines to the docs that lacked one.

## Acceptance criteria
- [x] No dead links or references to non-existent tools/files in README.
- [x] Country claim matches code.
- [x] Contributor docs separated from user README.

Not user-visible (documentation only) -- no changelog line needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)