### PR TITLE
fix: replace sed edits of addon.xml in release workflow with an XML parser

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,47 +25,18 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Get current plugin version
-      id: current_version
-      run: |
-        echo "Extracting version from addon.xml..."
-        ADDON_LINE=$(grep '^<addon' repo/plugin_video_mubi/addon.xml)
-        echo "Addon line: $ADDON_LINE"
-        CURRENT_VERSION=$(echo "$ADDON_LINE" | grep -o 'version="[^"]*"' | cut -d'"' -f2)
-        echo "Extracted version: $CURRENT_VERSION"
-
-        # Validate version is a number
-        if ! [[ "$CURRENT_VERSION" =~ ^[0-9]+$ ]]; then
-          echo "Error: Version '$CURRENT_VERSION' is not a valid integer"
-          exit 1
-        fi
-
-        echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-        echo "Current version: $CURRENT_VERSION"
-
-    - name: Increment plugin version
+    - name: Bump version and news in addon.xml
       id: new_version
+      # Parse/write addon.xml with a real XML parser instead of sed (issue #48):
+      # sed corrupted <news> on notes containing apostrophes/metacharacters.
+      # Notes are passed via env, never interpolated into the shell, to avoid
+      # script injection from the workflow input.
+      env:
+        RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
       run: |
-        CURRENT_VERSION=${{ steps.current_version.outputs.current_version }}
-        NEW_VERSION=$((CURRENT_VERSION + 1))
-        echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-        echo "New version: $NEW_VERSION"
-
-    - name: Update plugin addon.xml with new version
-      run: |
-        NEW_VERSION=${{ steps.new_version.outputs.new_version }}
-        # Only update the addon version, not dependency versions
-        sed -i "s/<addon id=\"plugin.video.mubi\" name=\"MUBI\" version=\"[^\"]*\"/<addon id=\"plugin.video.mubi\" name=\"MUBI\" version=\"$NEW_VERSION\"/" repo/plugin_video_mubi/addon.xml
-        echo "Updated plugin version to $NEW_VERSION"
-
-    - name: Update news section with release notes
-      run: |
-        NEW_VERSION=${{ steps.new_version.outputs.new_version }}
-        RELEASE_NOTES="${{ github.event.inputs.release_notes }}"
-        # Escape special characters for XML
-        ESCAPED_NOTES=$(echo "$RELEASE_NOTES" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')
-        sed -i "s|<news>.*</news>|<news>v$NEW_VERSION - $ESCAPED_NOTES</news>|" repo/plugin_video_mubi/addon.xml
-        echo "Updated news section with: v$NEW_VERSION - $RELEASE_NOTES"
+        NEW_VERSION=$(python3 scripts/bump_version.py --notes "$RELEASE_NOTES")
+        echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+        echo "Bumped plugin to v$NEW_VERSION with notes: $RELEASE_NOTES"
 
     - name: Generate repository files
       run: |

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Bump the plugin version and set the release news in `addon.xml`.
+
+This exists because the release workflow used to edit `addon.xml` with `sed`
+(a greedy `s|<news>.*</news>|...|` plus a hand-rolled XML escape table over
+user-supplied release notes). In v27 that produced nested `<news>` tags, and
+the same construction re-breaks on any note containing `sed` metacharacters
+(`|`, `&`, `\\`) or a second `<news>` block. Parsing with a real XML parser is
+the only robust fix (see DEVELOPMENT_PRINCIPLES.md P8).
+
+The version is an integer; this reads the current value, increments it by one,
+and writes both the `version` attribute and the `<news>` text back in a single
+parser pass -- no `sed`, no manual escaping.
+
+Run:  python3 scripts/bump_version.py --notes "Bug fixes and improvements"
+Prints the new version integer to stdout (for the workflow to capture).
+"""
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+_ADDON_XML = (
+    Path(__file__).resolve().parent.parent
+    / "repo"
+    / "plugin_video_mubi"
+    / "addon.xml"
+)
+
+
+def _read_declaration(path: Path) -> str:
+    """Return the original `<?xml ...?>` declaration line verbatim.
+
+    ElementTree drops the declaration on serialisation (and would rewrite it
+    without `standalone="yes"`), so we preserve the first line as-is.
+    """
+    with path.open("r", encoding="utf-8") as handle:
+        first_line = handle.readline().strip()
+    if not first_line.startswith("<?xml"):
+        raise ValueError(
+            "Expected an XML declaration on line 1 of {}".format(path)
+        )
+    return first_line
+
+
+def bump(notes, path=_ADDON_XML):
+    """Increment the addon version and set the news text.
+
+    Returns the new version integer. Raises ValueError if the current version
+    attribute is missing or not an integer, or if there is no `<news>` element.
+    """
+    path = Path(path)
+    declaration = _read_declaration(path)
+
+    tree = ET.parse(str(path))
+    root = tree.getroot()
+
+    current = root.get("version")
+    if current is None or not current.isdigit():
+        raise ValueError(
+            "addon version must be a non-negative integer, got {!r}".format(
+                current
+            )
+        )
+    new_version = int(current) + 1
+
+    news = root.find("./extension/metadata/news")
+    if news is None:
+        news = root.find(".//news")
+    if news is None:
+        raise ValueError("No <news> element found in {}".format(path))
+
+    root.set("version", str(new_version))
+    # Assigning to .text; ElementTree escapes &, <, > on serialisation and
+    # leaves quotes/apostrophes as valid text content.
+    news.text = "v{} - {}".format(new_version, notes)
+
+    body = ET.tostring(root, encoding="unicode")
+    # ElementTree renders empty elements as `<import ... />`; the hand-authored
+    # file uses `<import .../>` with no space. Normalise so each release diff is
+    # only the two intended lines. Safe here: `>` is escaped to `&gt;` in text,
+    # and no attribute value contains the literal sequence " />".
+    body = body.replace(" />", "/>")
+    path.write_text(declaration + "\n" + body + "\n", encoding="utf-8")
+
+    return new_version
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--notes",
+        required=True,
+        help="Release notes to place in the <news> element.",
+    )
+    parser.add_argument(
+        "--path",
+        default=str(_ADDON_XML),
+        help="Path to addon.xml (defaults to the plugin's addon.xml).",
+    )
+    args = parser.parse_args(argv)
+
+    new_version = bump(args.notes, args.path)
+    # stdout carries only the version so the workflow can capture it cleanly.
+    print(new_version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/bump_version.py.
+
+Regression for issue #48: the release workflow edited addon.xml with a greedy
+`sed` over user-supplied release notes, which produced nested <news> tags (v27)
+and re-breaks on sed/XML metacharacters. These tests feed adversarial notes and
+assert the file stays valid XML with correct values.
+"""
+
+import importlib.util
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "bump_version.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("bump_version", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bump_version = _load()
+
+
+ADDON_XML = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+    '<addon id="plugin.video.mubi" name="MUBI" version="29" provider-name="kubi2021">\n'
+    "  <extension point=\"xbmc.addon.metadata\">\n"
+    "    <news>v29 - Old notes</news>\n"
+    "  </extension>\n"
+    "</addon>\n"
+)
+
+
+@pytest.fixture
+def addon_file(tmp_path):
+    path = tmp_path / "addon.xml"
+    path.write_text(ADDON_XML, encoding="utf-8")
+    return path
+
+
+def _reparse(path):
+    return ET.parse(str(path)).getroot()
+
+
+def test_increments_version_and_sets_news(addon_file):
+    new_version = bump_version.bump("Bug fixes and improvements", addon_file)
+
+    assert new_version == 30
+    root = _reparse(addon_file)
+    assert root.get("version") == "30"
+    assert root.find(".//news").text == "v30 - Bug fixes and improvements"
+
+
+def test_apostrophe_does_not_corrupt_xml(addon_file):
+    # The v27 failure class: an apostrophe in the notes.
+    bump_version.bump("Fix Alice's watchlist", addon_file)
+
+    root = _reparse(addon_file)  # raises if the file is not well-formed
+    assert root.find(".//news").text == "v30 - Fix Alice's watchlist"
+
+
+@pytest.mark.parametrize(
+    "notes",
+    [
+        "amp & ampersand",
+        'double "quotes" here',
+        "angle <brackets> here",
+        "sed pipe | delimiter",
+        "sed backslash \\1 and replacement & chars",
+        "everything ' \" & < > | \\ at once",
+        "</news><news>injected second block",
+    ],
+)
+def test_adversarial_notes_stay_valid_xml(addon_file, notes):
+    bump_version.bump(notes, addon_file)
+
+    # 1. Still well-formed XML.
+    root = _reparse(addon_file)
+    # 2. Exactly one <news> element (no nesting / no injected second block).
+    news_elements = root.findall(".//news")
+    assert len(news_elements) == 1
+    # 3. The notes round-trip byte-for-byte through parse -> serialise -> parse.
+    assert news_elements[0].text == "v30 - {}".format(notes)
+
+
+def test_declaration_and_standalone_preserved(addon_file):
+    bump_version.bump("keep the prolog", addon_file)
+
+    first_line = addon_file.read_text(encoding="utf-8").splitlines()[0]
+    assert first_line == '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+
+
+def test_diff_is_only_the_two_intended_lines(tmp_path):
+    """Bumping must not reformat unrelated lines (self-closing tags etc.)."""
+    path = tmp_path / "addon.xml"
+    original = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        '<addon id="plugin.video.mubi" name="MUBI" version="29" provider-name="kubi2021">\n'
+        "  <requires>\n"
+        '    <import addon="xbmc.python" version="3.0.1"/>\n'
+        "  </requires>\n"
+        '  <extension point="xbmc.addon.metadata">\n'
+        "    <news>v29 - Old notes</news>\n"
+        "  </extension>\n"
+        "</addon>\n"
+    )
+    path.write_text(original, encoding="utf-8")
+
+    bump_version.bump("New notes", path)
+
+    original_lines = original.splitlines()
+    new_lines = path.read_text(encoding="utf-8").splitlines()
+    changed = [
+        i for i, (a, b) in enumerate(zip(original_lines, new_lines)) if a != b
+    ]
+    assert len(original_lines) == len(new_lines)
+    # Only the <addon ... version> line and the <news> line changed.
+    assert changed == [1, 6]
+    # Self-closing tag keeps the hand-authored `/>` (no space), not ET's ` />`.
+    assert '    <import addon="xbmc.python" version="3.0.1"/>' in new_lines
+
+
+def test_non_integer_version_rejected(tmp_path):
+    path = tmp_path / "addon.xml"
+    path.write_text(
+        ADDON_XML.replace('version="29"', 'version="1.2.3"'), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError):
+        bump_version.bump("notes", path)
+
+
+def test_missing_news_element_rejected(tmp_path):
+    path = tmp_path / "addon.xml"
+    path.write_text(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        '<addon id="plugin.video.mubi" name="MUBI" version="29">\n'
+        "</addon>\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        bump_version.bump("notes", path)
+
+
+def test_real_addon_xml_round_trips():
+    """The script must handle the real repo addon.xml, not just the fixture."""
+    real = (
+        Path(__file__).resolve().parent.parent
+        / "repo"
+        / "plugin_video_mubi"
+        / "addon.xml"
+    )
+    original = real.read_text(encoding="utf-8")
+    try:
+        current = int(ET.parse(str(real)).getroot().get("version"))
+        new_version = bump_version.bump("adversarial ' \" & < > | test", real)
+        assert new_version == current + 1
+        root = ET.parse(str(real)).getroot()  # raises if malformed
+        assert root.find(".//news").text == "v{} - adversarial ' \" & < > | test".format(
+            new_version
+        )
+    finally:
+        real.write_text(original, encoding="utf-8")


### PR DESCRIPTION
Closes #48.

## Problem
`.github/workflows/auto-release.yml` edited `addon.xml` with `sed`:
- a greedy `s|<news>.*</news>|...|` over user-supplied release notes (the v27 nested-`<news>` corruption), plus a hand-rolled XML escape table;
- release notes interpolated directly into the `run:` block (shell-injection vector);
- the `<addon ... version>` bump was a second `sed`.

Any note containing a `sed` metacharacter (`|`, `&`, `\`), an apostrophe, or a second `<news>` block re-triggers the corruption. Matches DEVELOPMENT_PRINCIPLES.md P8 and the CLAUDE.md "edit XML with a parser, not sed" lesson.

## Fix
- **`scripts/bump_version.py`** (stdlib `xml.etree.ElementTree`): reads `addon.xml`, increments the integer `version` attribute, sets `<news>` text in one parser pass — no `sed`, no manual escaping. Preserves the `<?xml … standalone="yes"?>` declaration and the hand-authored `/>` self-closing style, so each release diff is exactly the two intended lines.
- **Workflow**: four `sed`/`grep` steps collapsed into one call to the script; notes passed via `env:` (not interpolated into the shell); downstream steps keep the same `new_version` output.

## Tests
`tests/test_bump_version.py` (14 tests) feeds notes with `' " & < > | \` and an injected `</news><news>` block, asserting the file stays well-formed with exactly one `<news>` element and correct round-tripped values, plus declaration preservation, minimal-diff, and error cases.

## Acceptance criteria
- [x] No `sed` edits of `addon.xml` in the release workflow.
- [x] `addon.xml` round-trips through the bump script and stays valid XML for adversarial notes.
- [x] Test covers the escaping cases.

Not user-visible (release tooling only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
