### PR TITLE
ci: mask each OMDb key individually at the start of every sync workflow

### DIFF
--- a/.github/workflows/mubi_deep_sync.yml
+++ b/.github/workflows/mubi_deep_sync.yml
@@ -14,6 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Mask individual OMDb keys in logs
+      # GitHub masks a secret only as its exact full string. OMDB_API_KEYS is a
+      # comma-separated list, so a single key printed on its own (e.g. inside a
+      # requests error URL) would NOT be masked. Register each key separately,
+      # before anything else runs. Defense in depth for CLAUDE.md "never log a key".
+      env:
+        OMDB_API_KEYS: ${{ secrets.OMDB_API_KEYS }}
+      run: |
+        IFS=',' read -ra KEYS <<< "$OMDB_API_KEYS"
+        for key in "${KEYS[@]}"; do
+          key="${key//[[:space:]]/}"
+          if [ -n "$key" ]; then
+            echo "::add-mask::$key"
+          fi
+        done
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/mubi_shallow_sync.yml
+++ b/.github/workflows/mubi_shallow_sync.yml
@@ -14,6 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Mask individual OMDb keys in logs
+      # GitHub masks a secret only as its exact full string. OMDB_API_KEYS is a
+      # comma-separated list, so a single key printed on its own (e.g. inside a
+      # requests error URL) would NOT be masked. Register each key separately,
+      # before anything else runs. Defense in depth for CLAUDE.md "never log a key".
+      env:
+        OMDB_API_KEYS: ${{ secrets.OMDB_API_KEYS }}
+      run: |
+        IFS=',' read -ra KEYS <<< "$OMDB_API_KEYS"
+        for key in "${KEYS[@]}"; do
+          key="${key//[[:space:]]/}"
+          if [ -n "$key" ]; then
+            echo "::add-mask::$key"
+          fi
+        done
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/mubi_test_sync.yml
+++ b/.github/workflows/mubi_test_sync.yml
@@ -17,6 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Mask individual OMDb keys in logs
+      # GitHub masks a secret only as its exact full string. OMDB_API_KEYS is a
+      # comma-separated list, so a single key printed on its own (e.g. inside a
+      # requests error URL) would NOT be masked. Register each key separately,
+      # before anything else runs. Defense in depth for CLAUDE.md "never log a key".
+      env:
+        OMDB_API_KEYS: ${{ secrets.OMDB_API_KEYS }}
+      run: |
+        IFS=',' read -ra KEYS <<< "$OMDB_API_KEYS"
+        for key in "${KEYS[@]}"; do
+          key="${key//[[:space:]]/}"
+          if [ -n "$key" ]; then
+            echo "::add-mask::$key"
+          fi
+        done
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/tests/integration/test_sync_workflows_mask_keys.py
+++ b/tests/integration/test_sync_workflows_mask_keys.py
@@ -1,0 +1,52 @@
+"""CI gate: every sync workflow must register each OMDb key with ::add-mask:: first.
+
+GitHub masks a secret only as its exact full string, and OMDB_API_KEYS is a
+comma-separated list, so without this step a single key could appear verbatim in
+a public run log. Text-based on purpose: the repo has no YAML dependency.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+SYNC_WORKFLOWS = sorted(WORKFLOWS.glob("mubi_*_sync.yml"))
+STEP_RE = re.compile(r"^    - name: (.*)$", re.MULTILINE)
+
+
+def _step_names(text):
+    return STEP_RE.findall(text)
+
+
+def test_sync_workflows_are_discovered():
+    assert [p.name for p in SYNC_WORKFLOWS] == [
+        "mubi_deep_sync.yml",
+        "mubi_shallow_sync.yml",
+        "mubi_test_sync.yml",
+    ]
+
+
+@pytest.mark.parametrize("path", SYNC_WORKFLOWS, ids=lambda p: p.name)
+def test_first_step_masks_each_omdb_key(path):
+    text = path.read_text()
+    steps = _step_names(text)
+
+    assert steps, f"{path.name}: no steps found"
+    assert steps[0] == "Mask individual OMDb keys in logs", (
+        f"{path.name}: the mask step must run first, found {steps[0]!r}"
+    )
+    mask_block = text.split("- name: Mask individual OMDb keys in logs", 1)[1].split("- name:", 1)[0]
+    assert "OMDB_API_KEYS: ${{ secrets.OMDB_API_KEYS }}" in mask_block
+    assert "IFS=','" in mask_block, "keys must be split on commas"
+    assert '::add-mask::$key' in mask_block
+
+
+@pytest.mark.parametrize("path", SYNC_WORKFLOWS, ids=lambda p: p.name)
+def test_mask_step_precedes_every_use_of_the_omdb_secret(path):
+    text = path.read_text()
+    first_mask = text.index("- name: Mask individual OMDb keys in logs")
+    uses = [m.start() for m in re.finditer(r"OMDB_API_KEYS: \$\{\{ secrets\.OMDB_API_KEYS \}\}", text)]
+
+    assert len(uses) >= 2, f"{path.name}: expected the secret in the mask step and the enrich step"
+    assert all(first_mask < u for u in uses[1:])


### PR DESCRIPTION
## What & why (CI only)

Follow-up to the hostile audit of #60 (F1: API keys reached the public Actions log via requests error text).

GitHub masks a secret in run logs only as its **exact full string**. `OMDB_API_KEYS` is a comma-separated list, so an individual key printed on its own was not masked. This adds a first step to the three sync workflows (`mubi_deep_sync`, `mubi_shallow_sync`, `mubi_test_sync`) that splits the secret on commas, trims whitespace, skips empties and emits `::add-mask::` for each key, before checkout or any other output.

Defense in depth for the CLAUDE.md rule "never log a key or token": #60 fixed the code path, this makes the runner redact a key even if a future path logs one.

## Guard

`tests/integration/test_sync_workflows_mask_keys.py`: fails if any `mubi_*_sync.yml` lacks the step, does not run it first, or uses the secret before it. Text-based (no YAML dependency in the repo). Verified failing on the unmodified workflows (6 failed), passing after.

## Verification
- YAML parses (pyyaml); first step of each job is the mask step.
- `bash -n` on the extracted `run` blocks; dry-run with `"aaa111, bbb222,,ccc333 "` emits exactly three `::add-mask::` lines.

Not user-visible.
