### PR TITLE
fix: declare omdbapiKey setting so OMDb fallback works on new installs

### DIFF
--- a/docs/DEVELOPMENT_PRINCIPLES.md
+++ b/docs/DEVELOPMENT_PRINCIPLES.md
@@ -101,6 +101,12 @@ Decide explicitly, and document the decision in this file:
 - **Preferred:** make Fast Sync the default and the API‑crawl path a fallback. Then the plugin's `external_metadata` package becomes thin (read `imdb_id`/`tmdb_id` from the JSON) and the backend owns matching.
 - **Alternative:** if both paths must live on, put shared pure‑Python code (title normalisation, retry) in one place and copy it into the plugin at build time via `_repo_generator.py`, so there is one source of truth.
 
+**Decision (2026-09, issue #51): the plugin matcher stays, as a fallback.** Fast Sync is opt-in (`enable_fast_sync` defaults `false`, advanced level), so most installs still reach TMDB/OMDb through the plugin's `external_metadata` package. Retiring it would strip metadata from every non-Fast-Sync user, so it is kept. Consequences that follow from keeping it:
+
+- The backend copy stays canonical; the plugin copy is legacy. Fix a matching bug in both or neither (the rule below).
+- OMDb remains a live fallback provider in the plugin, so its `omdbapiKey` setting must exist. Issue #51 was that read with no declaration; the setting is now declared in `settings.xml`.
+- Sharing the pure-Python normalisation/retry via `_repo_generator.py` (the Alternative above) is still the eventual target but is out of scope here; until then, "fix both" is the guard against drift.
+
 Do not fix a matching bug in one copy without fixing it in the other.
 
 ### P6. Compare times as datetimes, never as strings.

--- a/repo/plugin_video_mubi/resources/settings.xml
+++ b/repo/plugin_video_mubi/resources/settings.xml
@@ -15,6 +15,17 @@
                     </control>
                 </setting>
 
+                <setting id="omdbapiKey" label="30001" type="string" help="">
+                    <level>0</level>
+                    <default/>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30001</heading>
+                    </control>
+                </setting>
+
                 <setting id="accept-language" label="30002" type="string" help="">
                     <level>0</level>
                     <default/>

--- a/tests/plugin_video_mubi/test_kodi_plugin_integration.py
+++ b/tests/plugin_video_mubi/test_kodi_plugin_integration.py
@@ -1354,14 +1354,28 @@ class TestSettingsDeclarations:
         return Path(__file__).parent.parent.parent / 'repo' / 'plugin_video_mubi'
 
     def _read_setting_keys(self):
-        """Collect every literal id passed to a getSetting* call in the plugin."""
+        """Collect every literal setting id read in the plugin.
+
+        Matches both a direct ``getSetting*("id")`` call and a read through the
+        ``session_manager._get_plugin_setting("id")`` wrapper, through which the
+        whole session surface (client_country, token, userID, deviceID, ...) is
+        read. A wrapper read would otherwise escape the scan, defeating the
+        "read but not declared" guard for that entire module.
+        """
         import re
         keys = set()
-        pattern = re.compile(
-            r'getSetting(?:Bool|Int|Number|String)?\(\s*["\']([A-Za-z0-9_-]+)["\']'
+        patterns = (
+            re.compile(
+                r'getSetting(?:Bool|Int|Number|String)?\(\s*["\']([A-Za-z0-9_-]+)["\']'
+            ),
+            re.compile(
+                r'_get_plugin_setting\(\s*["\']([A-Za-z0-9_-]+)["\']'
+            ),
         )
         for path in self._plugin_root().rglob('*.py'):
-            keys.update(pattern.findall(path.read_text(encoding='utf-8')))
+            text = path.read_text(encoding='utf-8')
+            for pattern in patterns:
+                keys.update(pattern.findall(text))
         return keys
 
     def _declared_setting_ids(self):
@@ -1387,4 +1401,19 @@ class TestSettingsDeclarations:
             f"These settings are read in the plugin but not declared in "
             f"settings.xml: {sorted(undeclared)}. Declare them, remove the read, "
             f"or add them to LEGACY_UNDECLARED_KEYS with a justification."
+        )
+
+    def test_scanner_sees_wrapper_reads(self):
+        """The scan must follow ``_get_plugin_setting``, not only direct calls.
+
+        session_manager reads every setting through the wrapper. If the scan only
+        matched direct ``getSetting*`` calls, an undeclared read added the
+        idiomatic session_manager way would ship silently. ``deviceID`` is read
+        exclusively via the wrapper (session_manager.py), so its presence proves
+        the wrapper path is scanned.
+        """
+        assert 'deviceID' in self._read_setting_keys(), (
+            "The settings scan no longer sees _get_plugin_setting() reads; the "
+            "whole session_manager surface (deviceID, token, userID, ...) would "
+            "escape the read-but-not-declared guard."
         )

--- a/tests/plugin_video_mubi/test_kodi_plugin_integration.py
+++ b/tests/plugin_video_mubi/test_kodi_plugin_integration.py
@@ -1327,3 +1327,64 @@ class TestSettingsCountrySync:
             f"Expected 248 countries, but found {len(COUNTRIES)}. "
             "If countries were intentionally added/removed, update this test."
         )
+
+
+class TestSettingsDeclarations:
+    """
+    Test that every addon setting the plugin reads is declared in settings.xml.
+
+    Regression guard for issue #51: ``MetadataProviderFactory`` read the
+    ``omdbapiKey`` setting, but no such setting was declared in settings.xml, so
+    for every new install the OMDb key was permanently empty and the OMDb
+    fallback provider could never be selected (the fallback path was dead).
+
+    A setting that is read but not declared is always a bug: Kodi returns "" for
+    unknown ids and the user has no way to populate it. See CLAUDE.md,
+    "Every getSetting* key must exist in resources/settings.xml".
+    """
+
+    # Keys that are read on purpose but intentionally NOT declared, with why.
+    # ``skip_genres`` is the obsolete free-text genre setting: migrations.py
+    # reads it once to migrate old profiles to the per-genre toggles, then
+    # clears it. It must never be re-declared. See migrations.py.
+    LEGACY_UNDECLARED_KEYS = {"skip_genres"}
+
+    def _plugin_root(self):
+        from pathlib import Path
+        return Path(__file__).parent.parent.parent / 'repo' / 'plugin_video_mubi'
+
+    def _read_setting_keys(self):
+        """Collect every literal id passed to a getSetting* call in the plugin."""
+        import re
+        keys = set()
+        pattern = re.compile(
+            r'getSetting(?:Bool|Int|Number|String)?\(\s*["\']([A-Za-z0-9_-]+)["\']'
+        )
+        for path in self._plugin_root().rglob('*.py'):
+            keys.update(pattern.findall(path.read_text(encoding='utf-8')))
+        return keys
+
+    def _declared_setting_ids(self):
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(self._plugin_root() / 'resources' / 'settings.xml')
+        return {s.get('id') for s in tree.getroot().iter('setting') if s.get('id')}
+
+    def test_omdbapikey_setting_is_declared(self):
+        """The specific setting from issue #51 must be declared."""
+        assert 'omdbapiKey' in self._declared_setting_ids(), (
+            "omdbapiKey is read by MetadataProviderFactory but not declared in "
+            "settings.xml, so the OMDb fallback is dead for new installs (#51)."
+        )
+
+    def test_all_read_settings_are_declared(self):
+        """Every setting the plugin reads is declared (or a known legacy key)."""
+        read_keys = self._read_setting_keys()
+        declared = self._declared_setting_ids()
+
+        undeclared = read_keys - declared - self.LEGACY_UNDECLARED_KEYS
+
+        assert not undeclared, (
+            f"These settings are read in the plugin but not declared in "
+            f"settings.xml: {sorted(undeclared)}. Declare them, remove the read, "
+            f"or add them to LEGACY_UNDECLARED_KEYS with a justification."
+        )


### PR DESCRIPTION
Fixes #51.

## Problem
`MetadataProviderFactory` reads the addon setting `omdbapiKey`, but no such setting was declared in `settings.xml`. Kodi returns `""` for undeclared ids, so on every new install the OMDb key was permanently empty and the OMDb fallback provider could never be selected — the fallback path was dead.

## Part A — the bug (fixed)
Declare `omdbapiKey` in `settings.xml` (level 0, empty default, `allowempty`), reusing the existing `#30001` "OMDB API Key" string that was already present in `strings.po`. OMDb is a real, tested fallback provider (`film.py`, `navigation_handler.py`), so keeping it alive is the correct fix rather than deleting the read.

## Part B — the decision (recorded)
Recorded under **P5** in `docs/DEVELOPMENT_PRINCIPLES.md`, where the doc itself asks the decision to live: **the plugin-side matcher stays, as a fallback.** Fast Sync is opt-in (`enable_fast_sync` defaults `false`), so most installs still reach TMDB/OMDb through the plugin's `external_metadata` package; retiring it would strip metadata from every non-Fast-Sync user. The backend copy stays canonical, the plugin copy legacy, and the existing "fix a matching bug in both or neither" rule is the guard against drift.

## Regression test
`TestSettingsDeclarations` in `test_kodi_plugin_integration.py`:
- `test_omdbapikey_setting_is_declared` — the specific #51 setting.
- `test_all_read_settings_are_declared` — scans the plugin for every `getSetting*("id")` literal and asserts each is declared, guarding the whole "read but not declared" class. The one deliberate exception, `skip_genres` (read once by `migrations.py`, then cleared), is allowlisted with rationale.

## Acceptance criteria
- [x] No setting is read that is not declared, or the read is removed.
- [x] A note in the repo records the plugin-matcher decision.

Not user-visible beyond restoring the intended OMDb fallback; no README changelog line needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
