### PR TITLE
feat: auto-enable Fast Sync for existing users on update (one-time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Whenever you want to **update** the local database, run the **sync** process aga
 
 ## Changelog
 
+### Sep 3rd, 2026 - Fast Sync by Default ⚡
+- **Fast Sync is now the default**: On update, existing users are automatically switched to the pre-computed GitHub catalogue ("Fast Sync") once. New installs start with it enabled too. You can still turn it back off in the add-on settings if you need the legacy per-country sync.
+
 ### Dec 30th, 2025 - Bayesian Ratings & Smarter Availability 🧠🎯
 - **Bayesian Ratings**: Introduced Bayesian composite ratings for the Fast Sync mode (currently in beta). This provides a more balanced and reliable scoring system by weighing ratings from multiple sources.
 - **Refined Availability Logic**: Fixed an issue where "upcoming" movies could appear in your library before they were actually playable. Now, films will only show up when they are truly available to watch.

--- a/repo/plugin_video_mubi/addon.py
+++ b/repo/plugin_video_mubi/addon.py
@@ -17,7 +17,8 @@ import xbmc
 from urllib.parse import parse_qsl, unquote_plus
 import xbmcgui
 from resources.lib.migrations import (
-    add_mubi_source, is_first_run, mark_first_run, migrate_genre_settings
+    add_mubi_source, is_first_run, mark_first_run, migrate_genre_settings,
+    migrate_to_fast_sync
 )
 
 def main(argv):
@@ -42,6 +43,11 @@ def main(argv):
     # Migrate old text-based genre settings to new toggle-based settings
     # This only runs once if the old skip_genres setting has a value
     migrate_genre_settings(plugin)
+
+    # One-time: move existing users onto the fast (GitHub) sync, sunsetting the
+    # legacy slow sync. Guarded by fast_sync_migration_done so it runs once and
+    # the user can still opt back out afterwards.
+    migrate_to_fast_sync(plugin)
 
 
 

--- a/repo/plugin_video_mubi/resources/language/resource.language.en_gb/strings.po
+++ b/repo/plugin_video_mubi/resources/language/resource.language.en_gb/strings.po
@@ -1230,7 +1230,7 @@ msgid "Sync"
 msgstr ""
 
 msgctxt "#30801"
-msgid "Enable Fast Sync (Beta)"
+msgid "Enable Fast Sync"
 msgstr ""
 
 msgctxt "#30802"

--- a/repo/plugin_video_mubi/resources/lib/migrations.py
+++ b/repo/plugin_video_mubi/resources/lib/migrations.py
@@ -106,6 +106,30 @@ def mark_first_run(plugin):
     plugin.setSettingBool('first_run_completed', True)
 
 
+def migrate_to_fast_sync(plugin):
+    """
+    One-time migration that switches existing users from the legacy "slow"
+    per-country MUBI sync to the pre-computed GitHub "fast" sync.
+
+    Kodi preserves each user's settings.xml across add-on updates, so changing
+    the shipped default of enable_fast_sync only affects fresh installs. This
+    flips the setting once for users who upgrade.
+
+    A separate hidden marker (fast_sync_migration_done) guards the flip so it
+    runs exactly once: the enable_fast_sync value itself cannot be the guard,
+    because True is also a legitimate user choice. After the migration the user
+    remains free to toggle enable_fast_sync back off; we never force it again.
+    """
+    if plugin.getSettingBool('fast_sync_migration_done'):
+        # Already migrated - respect whatever the user has set since.
+        return False
+
+    plugin.setSettingBool('enable_fast_sync', True)
+    plugin.setSettingBool('fast_sync_migration_done', True)
+    xbmc.log("Migrated user to fast sync (one-time)", level=xbmc.LOGINFO)
+    return True
+
+
 def migrate_genre_settings(plugin):
     """
     Migrate from old text-based skip_genres setting to new toggle-based settings.

--- a/repo/plugin_video_mubi/resources/settings.xml
+++ b/repo/plugin_video_mubi/resources/settings.xml
@@ -333,6 +333,11 @@
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
+                <setting id="fast_sync_migration_done" type="boolean" label="" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
             </group>
         </category>
         <category id="filters" label="30400" help="">
@@ -470,7 +475,7 @@
             <group id="1">
                 <setting id="enable_fast_sync" label="30801" type="boolean" help="30802">
                     <level>2</level>
-                    <default>false</default>
+                    <default>true</default>
                     <control type="toggle"/>
                 </setting>
             </group>

--- a/tests/plugin_video_mubi/test_addon.py
+++ b/tests/plugin_video_mubi/test_addon.py
@@ -120,6 +120,25 @@ class TestAddon:
         mocks['add_source'].assert_called_once()
         mocks['mark_first_run'].assert_called_once()
 
+    def test_main_runs_fast_sync_migration(self, mock_dependencies):
+        """main() must wire in the one-time fast-sync migration.
+
+        Regression guard for the PR #69 wiring: the whole feature depends on
+        main() calling migrate_to_fast_sync(plugin). Without this assertion the
+        call could be dropped and every other addon test would still pass.
+        """
+        from plugin_video_mubi import addon
+        mocks = mock_dependencies
+        mocks['session_instance'].client_country = 'US'
+        mocks['session_instance'].client_language = 'en'
+
+        with patch('plugin_video_mubi.addon.migrate_to_fast_sync') as mock_migrate:
+            argv = ["plugin://plugin.video.mubi/", "123", ""]
+            addon.main(argv)
+
+        # The migration runs exactly once, against the resolved Addon instance.
+        mock_migrate.assert_called_once_with(mocks['addon_instance'])
+
 
 class TestErrorHandling:
     """

--- a/tests/plugin_video_mubi/test_migrations.py
+++ b/tests/plugin_video_mubi/test_migrations.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock, patch, MagicMock
 import xml.etree.ElementTree as ET
 from plugin_video_mubi.resources.lib.migrations import (
     add_mubi_source, read_xml, write_xml, show_source_added_message,
-    is_first_run, mark_first_run, migrate_genre_settings
+    is_first_run, mark_first_run, migrate_genre_settings, migrate_to_fast_sync
 )
 
 
@@ -453,3 +453,47 @@ class TestMigrateGenreSettings:
         assert result is True
         calls = mock_addon.setSettingBool.call_args_list
         assert len(calls) == 3
+
+
+class TestMigrateToFastSync:
+    """Test cases for the one-time fast-sync migration."""
+
+    @patch('xbmc.log')
+    def test_migrate_to_fast_sync_flips_setting_on_first_run(self, mock_log, mock_addon):
+        """An un-migrated user gets enable_fast_sync forced True and the marker set."""
+        # Marker not yet set -> migration should run.
+        mock_addon.getSettingBool.return_value = False
+
+        result = migrate_to_fast_sync(mock_addon)
+
+        assert result is True
+        mock_addon.setSettingBool.assert_any_call('enable_fast_sync', True)
+        mock_addon.setSettingBool.assert_any_call('fast_sync_migration_done', True)
+
+    @patch('xbmc.log')
+    def test_migrate_to_fast_sync_is_idempotent(self, mock_log, mock_addon):
+        """Once the marker is set the migration never touches enable_fast_sync again."""
+        # Marker already set -> migration is a no-op.
+        mock_addon.getSettingBool.return_value = True
+
+        result = migrate_to_fast_sync(mock_addon)
+
+        assert result is False
+        mock_addon.setSettingBool.assert_not_called()
+
+    @patch('xbmc.log')
+    def test_migrate_to_fast_sync_respects_user_opt_out_after_migration(self, mock_log, mock_addon):
+        """A user who turned fast sync back off is not re-forced on a later launch.
+
+        Regression guard: the marker, not the enable_fast_sync value, is the
+        idempotency key, so opting back out must survive subsequent launches.
+        """
+        mock_addon.getSettingBool.side_effect = lambda key: {
+            'fast_sync_migration_done': True,
+            'enable_fast_sync': False,  # user opted back out
+        }[key]
+
+        result = migrate_to_fast_sync(mock_addon)
+
+        assert result is False
+        mock_addon.setSettingBool.assert_not_called()


### PR DESCRIPTION
## What

Auto-enables **Fast Sync** (the pre-computed GitHub catalogue) for existing users via a one-time migration on update, and makes it the default for fresh installs. First step toward sunsetting the legacy per-country "slow sync".

## Why

Kodi preserves each user's `settings.xml` across add-on updates, so changing the shipped `<default>` of `enable_fast_sync` only reaches **fresh installs** — existing users would stay on slow sync forever. Migrating them requires code that runs on update.

## How

- `migrate_to_fast_sync(plugin)` in `migrations.py`, called from `addon.py:main()` alongside the existing migrations.
- Guarded by a **separate hidden marker** `fast_sync_migration_done` — not the `enable_fast_sync` value itself, because `true` is also a legitimate user choice. This makes the flip run **exactly once** and lets a user who turns Fast Sync back off stay off on later launches.
- Shipped default of `enable_fast_sync` flipped to `true` for fresh installs.

## Staged sunset

This is **stage 1**: Fast Sync becomes the default but the toggle and slow-sync code remain as an escape hatch (e.g. a country the DB doesn't cover). **Stage 2**, later, is the hard removal of the toggle and the `sync_locally`/`sync_worldwide` paths once Fast Sync is proven.

## User-visible

Yes — README changelog line added.

## Tests

3 regression tests in `test_migrations.py` (flip-on-first-run, idempotency, opt-out-survives-later-launch). `pytest tests/plugin_video_mubi/test_migrations.py` → 35 passed; `test_addon.py` → 31 passed; `settings.xml` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
