### PR TITLE
Adopt ruff, fix all F/E/W/I findings, gate lint in CI (#49)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,26 @@ on:
     branches: [ main, master ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Ruff lint
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install ruff
+      run: pip install ruff==0.16.6  # pinned so a new ruff release cannot fail CI without a config bump
+
+    - name: Ruff check (lint)
+      run: ruff check repo/plugin_video_mubi backend
+
+    - name: Ruff format (check only)
+      run: ruff format --check repo/plugin_video_mubi backend
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/backend/enrich_metadata.py
+++ b/backend/enrich_metadata.py
@@ -7,15 +7,18 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # Try to import dotenv for local development
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
-    logger.warning("python-dotenv library not found. .env file will be ignored. Install with: pip install python-dotenv")
+    logger.warning(
+        "python-dotenv library not found. .env file will be ignored. Install with: pip install python-dotenv"
+    )
 
 # Ensure backend package can be imported if running directly
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -24,9 +27,9 @@ from backend.omdb_provider import OMDBProvider  # noqa: E402  (import after sys.
 from backend.tmdb_provider import TMDBProvider  # noqa: E402  (import after sys.path setup above)
 
 
-def enrich_metadata(films_path='films.json', content_type='movie'):
+def enrich_metadata(films_path="films.json", content_type="movie"):
     # 1. Load Environment & Config
-    api_key = os.environ.get('TMDB_API_KEY')
+    api_key = os.environ.get("TMDB_API_KEY")
     if not api_key:
         logger.error("TMDB_API_KEY environment variable not set. Skipping metadata enrichment.")
         sys.exit(1)
@@ -38,16 +41,16 @@ def enrich_metadata(films_path='films.json', content_type='movie'):
     # Support single variable with comma-separated keys (OMDB_API_KEYS)
     # Also support legacy single key (OMDB_API_KEY) for backward compatibility
     omdb_keys = []
-    
-    env_keys = os.environ.get('OMDB_API_KEYS')
+
+    env_keys = os.environ.get("OMDB_API_KEYS")
     if env_keys:
-        omdb_keys.extend([k.strip() for k in env_keys.split(',') if k.strip()])
-        
+        omdb_keys.extend([k.strip() for k in env_keys.split(",") if k.strip()])
+
     # Fallback/Additional check for single key
-    single_key = os.environ.get('OMDB_API_KEY')
+    single_key = os.environ.get("OMDB_API_KEY")
     if single_key and single_key not in omdb_keys:
         omdb_keys.append(single_key)
-            
+
     if not omdb_keys:
         # Fallback for local dev if needed, or raise warning
         logger.warning("No OMDB_API_KEYS found in environment. OMDB enrichment will be skipped or limited.")
@@ -61,9 +64,9 @@ def enrich_metadata(films_path='films.json', content_type='movie'):
         sys.exit(1)
 
     try:
-        with open(films_path, 'r', encoding='utf-8') as f:
+        with open(films_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-            items = data.get('items', [])
+            items = data.get("items", [])
     except Exception as e:
         logger.error(f"Failed to load JSON: {e}")
         sys.exit(1)
@@ -71,27 +74,27 @@ def enrich_metadata(films_path='films.json', content_type='movie'):
     # 3. Identify items needing enrichment
     items_to_process = []
     for i, film in enumerate(items):
-        has_imdb = bool(film.get('imdb_id'))
-        has_tmdb = bool(film.get('tmdb_id'))
-        
+        has_imdb = bool(film.get("imdb_id"))
+        has_tmdb = bool(film.get("tmdb_id"))
+
         # Check if we need OMDB enrichment
         needs_omdb = False
         if has_imdb:
-            ratings = film.get('ratings', [])
-            has_imdb_rating = any(r.get('source') == 'imdb' for r in ratings)
+            ratings = film.get("ratings", [])
+            has_imdb_rating = any(r.get("source") == "imdb" for r in ratings)
             if not has_imdb_rating:
                 needs_omdb = True
 
         if has_tmdb and not needs_omdb:
             continue
-            
+
         if not has_tmdb or needs_omdb:
             items_to_process.append((i, film))
 
     total_films = len(items)
     to_process_count = len(items_to_process)
     logger.info(f"Loaded {total_films} films. Found {to_process_count} needing enrichment.")
-    
+
     if to_process_count == 0:
         logger.info("No films need enrichment.")
         return
@@ -101,17 +104,20 @@ def enrich_metadata(films_path='films.json', content_type='movie'):
 
     max_workers = 10
     logger.info(f"Starting enrichment with {max_workers} workers...")
-    
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         # Submit all tasks
-        futures = {executor.submit(process_film, film, provider, omdb_provider, idx, total_films, content_type): idx for idx, film in items_to_process}
-        
+        futures = {
+            executor.submit(process_film, film, provider, omdb_provider, idx, total_films, content_type): idx
+            for idx, film in items_to_process
+        }
+
         completed_so_far = 0
-        
+
         for future in concurrent.futures.as_completed(futures):
             completed_so_far += 1
             idx = futures[future]
-            
+
             try:
                 result = future.result()
                 if result:
@@ -120,22 +126,18 @@ def enrich_metadata(films_path='films.json', content_type='movie'):
                 logger.error(f"Error processing film index {idx}: {e}")
 
     logger.info(f"Enrichment complete. Updated {updated_count} films.")
-    
+
     # --- Global Stats Report ---
-    stats = {
-        "no_tmdb_id": 0,
-        "no_tmdb_rating": 0,
-        "no_imdb_rating": 0
-    }
-    
+    stats = {"no_tmdb_id": 0, "no_tmdb_rating": 0, "no_imdb_rating": 0}
+
     for film in items:
         if not film.get("tmdb_id"):
             stats["no_tmdb_id"] += 1
-            
+
         ratings = film.get("ratings", [])
         has_tmdb_rating = any(r.get("source") == "tmdb" for r in ratings)
         has_imdb_rating = any(r.get("source") == "imdb" for r in ratings)
-        
+
         if not has_tmdb_rating:
             stats["no_tmdb_rating"] += 1
         if not has_imdb_rating:
@@ -145,15 +147,16 @@ def enrich_metadata(films_path='films.json', content_type='movie'):
 
     # 4. Save
     if updated_count > 0:
-        data['items'] = items
-        
-        with open(films_path, 'w', encoding='utf-8') as f:
+        data["items"] = items
+
+        with open(films_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
-        
+
         duration = datetime.now() - start_time
         logger.info(f"Enrichment complete. Updated {updated_count} films in {duration}.")
     else:
         logger.info("Enrichment complete. No new metadata found.")
+
 
 def generate_report(stats: Dict[str, int], omdb_provider: Optional[OMDBProvider], total: int, updated: int):
     """Log a comprehensive stats report."""
@@ -161,8 +164,9 @@ def generate_report(stats: Dict[str, int], omdb_provider: Optional[OMDBProvider]
         return
 
     def pct(count, total):
-        if total == 0: return "0 (0.0%)"
-        return f"{count} ({count/total*100:.1f}%)"
+        if total == 0:
+            return "0 (0.0%)"
+        return f"{count} ({count / total * 100:.1f}%)"
 
     logger.info("=" * 60)
     logger.info(f"GLOBAL STATS REPORT ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})")
@@ -174,7 +178,7 @@ def generate_report(stats: Dict[str, int], omdb_provider: Optional[OMDBProvider]
     logger.info(f"NO TMDB Rating:        {pct(stats['no_tmdb_rating'], total)}")
     logger.info(f"NO IMDB Rating:        {pct(stats['no_imdb_rating'], total)}")
     logger.info("-" * 60)
-    
+
     if omdb_provider:
         try:
             failed_keys = omdb_provider.get_failed_keys()
@@ -186,100 +190,106 @@ def generate_report(stats: Dict[str, int], omdb_provider: Optional[OMDBProvider]
             else:
                 logger.info("OMDB Keys: All healthy (or none used).")
         except AttributeError:
-             logger.info("OMDB Provider: Does not support key reporting.")
+            logger.info("OMDB Provider: Does not support key reporting.")
     else:
         logger.info("OMDB Provider: Disabled/Not initialized.")
-        
+
     logger.info("=" * 60)
 
     # Validation
     # ...
 
-def process_film(film: Dict[str, Any], provider: TMDBProvider, omdb_provider: Optional[OMDBProvider], idx: int, total: int, media_type: str = "movie") -> bool:
+
+def process_film(
+    film: Dict[str, Any],
+    provider: TMDBProvider,
+    omdb_provider: Optional[OMDBProvider],
+    idx: int,
+    total: int,
+    media_type: str = "movie",
+) -> bool:
     """
     Process a single film to fetch external metadata.
     Returns True if updated, False otherwise.
     """
-    title = film.get('title')
-    original_title = film.get('original_title')
-    year = film.get('year')
-    directors = film.get('directors', [])
-    duration = film.get('duration')
-    genres = film.get('genres', [])
-    
-    mubi_id = film.get('mubi_id')
-    
-    logger.info(f"[{idx+1}/{total}] Fetching metadata for '{title}' ({year}) [MubiID:{mubi_id}]...")
-    
+    title = film.get("title")
+    original_title = film.get("original_title")
+    year = film.get("year")
+    directors = film.get("directors", [])
+    duration = film.get("duration")
+    genres = film.get("genres", [])
+
+    mubi_id = film.get("mubi_id")
+
+    logger.info(f"[{idx + 1}/{total}] Fetching metadata for '{title}' ({year}) [MubiID:{mubi_id}]...")
+
     if not title:
         return False
 
-    tmdb_id = film.get('tmdb_id')
-    
+    tmdb_id = film.get("tmdb_id")
+
     result = provider.get_imdb_id(
-        title, 
-        original_title=original_title, 
-        year=year, 
-        media_type=media_type, 
+        title,
+        original_title=original_title,
+        year=year,
+        media_type=media_type,
         tmdb_id=tmdb_id,
         mubi_directors=directors,
         mubi_runtime=duration,
         mubi_genres=genres,
-        mubi_id=mubi_id
+        mubi_id=mubi_id,
     )
-    
+
     if result.success:
         if result.imdb_id:
-            film['imdb_id'] = result.imdb_id
+            film["imdb_id"] = result.imdb_id
         if result.tmdb_id:
-            film['tmdb_id'] = result.tmdb_id
-        
+            film["tmdb_id"] = result.tmdb_id
+
         # Build ratings array
         ratings = []
-        
+
         # Add Mubi rating (from existing fields)
-        mubi_rating = film.get('average_rating_out_of_ten')
-        mubi_voters = film.get('number_of_ratings')
+        mubi_rating = film.get("average_rating_out_of_ten")
+        mubi_voters = film.get("number_of_ratings")
         if mubi_rating is not None:
-            ratings.append({
-                "source": "mubi",
-                "score_over_10": float(mubi_rating),
-                "voters": int(mubi_voters) if mubi_voters else 0
-            })
-        
+            ratings.append(
+                {
+                    "source": "mubi",
+                    "score_over_10": float(mubi_rating),
+                    "voters": int(mubi_voters) if mubi_voters else 0,
+                }
+            )
+
         # Add TMDB rating
         if result.vote_average is not None:
-            ratings.append({
-                "source": "tmdb",
-                "score_over_10": result.vote_average,
-                "voters": result.vote_count or 0
-            })
-        
+            ratings.append({"source": "tmdb", "score_over_10": result.vote_average, "voters": result.vote_count or 0})
+
         # 3. OMDB Enrichment
         # Only attempt if provider has valid keys
-        imdb_id = film.get('imdb_id')
+        imdb_id = film.get("imdb_id")
         if imdb_id and omdb_provider and omdb_provider.api_keys:
             omdb_result = omdb_provider.get_details(imdb_id)
-            if omdb_result.success and hasattr(omdb_result, 'extra_ratings'):
+            if omdb_result.success and hasattr(omdb_result, "extra_ratings"):
                 ratings.extend(omdb_result.extra_ratings)
                 logger.info(f"Found match: OMDB for '{title}'")
-        
+
         if ratings:
-            film['ratings'] = ratings
-        
+            film["ratings"] = ratings
+
         logger.info(f"Found match [MubiID:{mubi_id}]: IMDB={result.imdb_id}, TMDB={result.tmdb_id}")
         return True
     else:
         logger.warning(f"No match found for '{title}' ({year}) [MubiID:{mubi_id}]")
         return False
-    
 
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(description="Enrich Mubi Catalog with TMDB/IMDB IDs")
-    parser.add_argument('--path', default='films.json', help="Path to films.json")
-    parser.add_argument('--type', choices=['movie', 'series'], default='movie', help="Content type (movie or series)")
-    
+    parser.add_argument("--path", default="films.json", help="Path to films.json")
+    parser.add_argument("--type", choices=["movie", "series"], default="movie", help="Content type (movie or series)")
+
     args = parser.parse_args()
     enrich_metadata(args.path, args.type)

--- a/backend/enrich_metadata.py
+++ b/backend/enrich_metadata.py
@@ -1,10 +1,10 @@
+import concurrent.futures
 import json
+import logging
 import os
 import sys
-import logging
-import concurrent.futures
 from datetime import datetime
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, Optional
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -20,8 +20,9 @@ except ImportError:
 # Ensure backend package can be imported if running directly
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from backend.tmdb_provider import TMDBProvider
-from backend.omdb_provider import OMDBProvider
+from backend.omdb_provider import OMDBProvider  # noqa: E402  (import after sys.path setup above)
+from backend.tmdb_provider import TMDBProvider  # noqa: E402  (import after sys.path setup above)
+
 
 def enrich_metadata(films_path='films.json', content_type='movie'):
     # 1. Load Environment & Config

--- a/backend/generate_repo.py
+++ b/backend/generate_repo.py
@@ -1,9 +1,8 @@
 import gzip
 import hashlib
-import json
-import shutil
-import os
 import logging
+import os
+import shutil
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/backend/generate_repo.py
+++ b/backend/generate_repo.py
@@ -5,10 +5,11 @@ import os
 import shutil
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-def generate_repo(input_file='films.json'):
+
+def generate_repo(input_file="films.json"):
     if not os.path.exists(input_file):
         logger.error(f"Input file {input_file} not found.")
         return
@@ -16,30 +17,32 @@ def generate_repo(input_file='films.json'):
     # 1. Compress to .gz
     gz_file = f"{input_file}.gz"
     logger.info(f"Compressing {input_file} to {gz_file}...")
-    with open(input_file, 'rb') as f_in:
-        with gzip.open(gz_file, 'wb') as f_out:
+    with open(input_file, "rb") as f_in:
+        with gzip.open(gz_file, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
-    
+
     # 2. Calculate MD5 of the .gz file
     logger.info(f"Calculating MD5 for {gz_file}...")
     with open(gz_file, "rb") as f:
         file_hash = hashlib.md5()
         while chunk := f.read(8192):
             file_hash.update(chunk)
-    
+
     md5_digest = file_hash.hexdigest()
-    
+
     # 3. Save MD5 to .md5 file
     md5_file = f"{gz_file}.md5"
     with open(md5_file, "w") as f:
         f.write(md5_digest)
-    
+
     logger.info(f"Generated {md5_file}: {md5_digest}")
+
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(description="Generate GZIP and MD5 for repository files")
-    parser.add_argument('--file', default='films.json', help="Input JSON file to process")
-    
+    parser.add_argument("--file", default="films.json", help="Input JSON file to process")
+
     args = parser.parse_args()
     generate_repo(args.file)

--- a/backend/generate_weekly_digest.py
+++ b/backend/generate_weekly_digest.py
@@ -8,33 +8,33 @@ from pathlib import Path
 from typing import Optional
 
 # Configuration
-INPUT_FILE = Path('/Users/kubi/Downloads/films.json')
+INPUT_FILE = Path("/Users/kubi/Downloads/films.json")
 REPO_ROOT = Path(__file__).parent.parent
-OUTPUT_FILE = REPO_ROOT / 'tmp' / 'weekly_digest.md'
+OUTPUT_FILE = REPO_ROOT / "tmp" / "weekly_digest.md"
 DAYS_LOOKBACK = 7
 
 
 def get_bayesian_score(film: dict) -> float:
     """Extract Bayesian score from ratings array."""
-    for rating in film.get('ratings', []):
-        if rating.get('source') == 'bayesian':
-            return rating.get('score_over_10', 0) or 0
+    for rating in film.get("ratings", []):
+        if rating.get("source") == "bayesian":
+            return rating.get("score_over_10", 0) or 0
     return 0
 
 
 def get_rating_value(film: dict, source: str) -> Optional[float]:
     """Extract specific rating value from ratings array."""
-    for rating in film.get('ratings', []):
-        if rating.get('source') == source:
-            return rating.get('score_over_10')
+    for rating in film.get("ratings", []):
+        if rating.get("source") == source:
+            return rating.get("score_over_10")
     return None
 
 
 def get_rating_voters(film: dict, source: str) -> Optional[int]:
     """Extract voter count for a specific rating source."""
-    for rating in film.get('ratings', []):
-        if rating.get('source') == source:
-            return rating.get('voters')
+    for rating in film.get("ratings", []):
+        if rating.get("source") == source:
+            return rating.get("voters")
     return None
 
 
@@ -43,28 +43,28 @@ def get_earliest_availability(film: dict) -> Optional[datetime]:
     Get the earliest available_at date across all countries for a film.
     Returns None if no valid dates found.
     """
-    available_countries = film.get('available_countries', {})
+    available_countries = film.get("available_countries", {})
     if not available_countries:
         return None
-    
+
     earliest_date = None
-    
+
     for country_code, country_data in available_countries.items():
-        avail_str = country_data.get('available_at')
+        avail_str = country_data.get("available_at")
         if not avail_str:
             continue
-        
+
         try:
             # Parse ISO format date, handle Z suffix
-            if avail_str.endswith('Z'):
-                avail_str = avail_str[:-1] + '+00:00'
+            if avail_str.endswith("Z"):
+                avail_str = avail_str[:-1] + "+00:00"
             avail_dt = datetime.fromisoformat(avail_str)
-            
+
             if earliest_date is None or avail_dt < earliest_date:
                 earliest_date = avail_dt
         except ValueError:
             continue
-    
+
     return earliest_date
 
 
@@ -73,91 +73,92 @@ def get_latest_expiration(film: dict) -> Optional[datetime]:
     Get the latest expires_at date across all countries for a film.
     Returns None if no keys or valid dates found.
     """
-    available_countries = film.get('available_countries', {})
+    available_countries = film.get("available_countries", {})
     if not available_countries:
         return None
-    
+
     latest_date = None
-    
+
     for country_code, country_data in available_countries.items():
-        expires_str = country_data.get('expires_at')
+        expires_str = country_data.get("expires_at")
         if not expires_str:
             continue
-        
+
         try:
             # Parse ISO format date, handle Z suffix
-            if expires_str.endswith('Z'):
-                expires_str = expires_str[:-1] + '+00:00'
+            if expires_str.endswith("Z"):
+                expires_str = expires_str[:-1] + "+00:00"
             expires_dt = datetime.fromisoformat(expires_str)
-            
+
             if latest_date is None or expires_dt > latest_date:
                 latest_date = expires_dt
         except ValueError:
             continue
-    
+
     return latest_date
 
 
 def format_rating_line(film: dict) -> str:
     """Format the ratings line for a film."""
     parts = []
-    
+
     bayesian = get_bayesian_score(film)
     if bayesian:
         parts.append(f"⭐ **{bayesian:.1f}** (Bayesian)")
-    
-    mubi = film.get('average_rating_out_of_ten')
+
+    mubi = film.get("average_rating_out_of_ten")
     if mubi:
         parts.append(f"Mubi: {mubi:.1f}")
-    
-    imdb = get_rating_value(film, 'imdb')
+
+    imdb = get_rating_value(film, "imdb")
     if imdb:
         parts.append(f"IMDb: {imdb:.1f}")
-    
-    tmdb = get_rating_value(film, 'tmdb')
+
+    tmdb = get_rating_value(film, "tmdb")
     if tmdb:
         parts.append(f"TMDB: {tmdb:.1f}")
-    
+
+
 def generate_digest(input_file: Path, output_file: Path, now_override: Optional[datetime] = None) -> None:
     """Main logic to generate the digest."""
     print(f"Loading data from {input_file}...")
-    
+
     if not input_file.exists():
         print(f"Error: {input_file} not found.")
         sys.exit(1)
-    
-    with open(input_file, 'r', encoding='utf-8') as f:
+
+    with open(input_file, "r", encoding="utf-8") as f:
         data = json.load(f)
-    
-    items = data.get('items', [])
+
+    items = data.get("items", [])
     total_movies = len(items)
     print(f"Total items loaded: {total_movies}")
-    
+
     # Get current time and calculate cutoff
     now = now_override or datetime.now(timezone.utc)
     cutoff_date = now - timedelta(days=DAYS_LOOKBACK)
-    
+
     print(f"Current time (UTC): {now.isoformat()}")
     print(f"Cutoff date: {cutoff_date.isoformat()}")
     print(f"Filtering movies with earliest availability >= {cutoff_date.date()}...")
-    
+
     # Find new movies
     new_movies = []
-    
+
     for film in items:
         earliest_date = get_earliest_availability(film)
         if earliest_date and earliest_date >= cutoff_date:
-            film['_earliest_availability'] = earliest_date  # Store for debugging
+            film["_earliest_availability"] = earliest_date  # Store for debugging
             new_movies.append(film)
-    
+
     print(f"Found {len(new_movies)} new movies in the past {DAYS_LOOKBACK} days.")
-    
+
     # Sort by Bayesian rating (descending)
     new_movies.sort(key=get_bayesian_score, reverse=True)
-    
+
     # Prepare JSON data structure
     json_movies = []
-    
+
     # Prepare Markdown content
     md_lines = [
         "# Mubi Weekly Digest",
@@ -169,123 +170,126 @@ def generate_digest(input_file: Path, output_file: Path, now_override: Optional[
         f"- **New Arrivals (Past 7 Days)**: {len(new_movies)}",
         "",
         "## New Arrivals",
-        ""
+        "",
     ]
-    
+
     if not new_movies:
         md_lines.append("No new movies found in the past 7 days.")
-    
+
     for i, film in enumerate(new_movies, 1):
-        title = film.get('title', 'Unknown Title')
-        year = film.get('year')
-        duration = film.get('duration')
-        genres = film.get('genres', [])
-        synopsis = film.get('short_synopsis', '')
-        trailer_url = film.get('trailer_url')
-        historic_countries = film.get('historic_countries', [])
-        directors = film.get('directors', [])
-        
+        title = film.get("title", "Unknown Title")
+        year = film.get("year")
+        duration = film.get("duration")
+        genres = film.get("genres", [])
+        synopsis = film.get("short_synopsis", "")
+        trailer_url = film.get("trailer_url")
+        historic_countries = film.get("historic_countries", [])
+        directors = film.get("directors", [])
+
         # Determine image URL
-        stills = film.get('stills') or {}
-        image_url = stills.get('medium') or film.get('still_url')
-        
+        stills = film.get("stills") or {}
+        image_url = stills.get("medium") or film.get("still_url")
+
         # Ratings
         bayesian = get_bayesian_score(film)
-        mubi = film.get('average_rating_out_of_ten')
-        imdb = get_rating_value(film, 'imdb')
-        tmdb = get_rating_value(film, 'tmdb')
-        
+        mubi = film.get("average_rating_out_of_ten")
+        imdb = get_rating_value(film, "imdb")
+        tmdb = get_rating_value(film, "tmdb")
+
         # Expiration
         latest_expires = get_latest_expiration(film)
         available_until = latest_expires.isoformat() if latest_expires else None
-        
+
         # Build JSON entry
-        json_movies.append({
-            "id": film.get('mubi_id'),
-            "imdbId": film.get('imdb_id'),
-            "tmdbId": film.get('tmdb_id'),
-            "title": title,
-            "year": year,
-            "bayesian": bayesian or None,
-            "bayesianVoters": get_rating_voters(film, 'bayesian'),
-            "mubi": mubi,
-            "mubiVoters": film.get('number_of_ratings'),
-            "imdb": imdb,
-            "imdbVoters": get_rating_voters(film, 'imdb'),
-            "tmdb": tmdb,
-            "tmdbVoters": get_rating_voters(film, 'tmdb'),
-            "genres": genres,
-            "duration": duration,
-            "countries": historic_countries,
-            "directors": directors,
-            "synopsis": synopsis,
-            "imageUrl": image_url,
-            "trailerUrl": trailer_url,
-            "availableUntil": available_until
-        })
-        
+        json_movies.append(
+            {
+                "id": film.get("mubi_id"),
+                "imdbId": film.get("imdb_id"),
+                "tmdbId": film.get("tmdb_id"),
+                "title": title,
+                "year": year,
+                "bayesian": bayesian or None,
+                "bayesianVoters": get_rating_voters(film, "bayesian"),
+                "mubi": mubi,
+                "mubiVoters": film.get("number_of_ratings"),
+                "imdb": imdb,
+                "imdbVoters": get_rating_voters(film, "imdb"),
+                "tmdb": tmdb,
+                "tmdbVoters": get_rating_voters(film, "tmdb"),
+                "genres": genres,
+                "duration": duration,
+                "countries": historic_countries,
+                "directors": directors,
+                "synopsis": synopsis,
+                "imageUrl": image_url,
+                "trailerUrl": trailer_url,
+                "availableUntil": available_until,
+            }
+        )
+
         # Markdown formatting
         rating_str_parts = []
-        if bayesian: rating_str_parts.append(f"Bayesian: **{bayesian:.1f}**")
-        if mubi: rating_str_parts.append(f"Mubi: {mubi}")
-        if imdb: rating_str_parts.append(f"IMDb: {imdb}")
-        if tmdb: rating_str_parts.append(f"TMDB: {tmdb}")
-        
+        if bayesian:
+            rating_str_parts.append(f"Bayesian: **{bayesian:.1f}**")
+        if mubi:
+            rating_str_parts.append(f"Mubi: {mubi}")
+        if imdb:
+            rating_str_parts.append(f"IMDb: {imdb}")
+        if tmdb:
+            rating_str_parts.append(f"TMDB: {tmdb}")
+
         rating_line = " | ".join(rating_str_parts) if rating_str_parts else "No ratings available"
         genres_str = ", ".join(genres)
-        
+
         md_lines.append(f"### {i}. {title} ({year})")
-        
+
         if image_url:
             md_lines.append(f"\n![{title}]({image_url})")
-            
+
         md_lines.append(f"\n**{rating_line}**")
         md_lines.append(f"\n**Genre**: {genres_str} | **Duration**: {duration} min")
         if available_until:
-             md_lines.append(f" | **Available until**: {latest_expires.strftime('%Y-%m-%d')}")
-        
+            md_lines.append(f" | **Available until**: {latest_expires.strftime('%Y-%m-%d')}")
+
         if synopsis:
-             md_lines.append(f"\n> {synopsis}")
-             
+            md_lines.append(f"\n> {synopsis}")
+
         if trailer_url:
             md_lines.append(f"\n[Watch Trailer]({trailer_url})")
-            
+
         md_lines.append("\n---")
 
     # Write Markdown
     print(f"Writing Markdown to {output_file}...")
     # Ensure tmp dir exists
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_file, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(md_lines))
-        
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write("\n".join(md_lines))
+
     # Write JSON
-    json_output_file = output_file.with_suffix('.json')
+    json_output_file = output_file.with_suffix(".json")
     print(f"Writing JSON to {json_output_file}...")
-    
-    json_data = {
-        "generatedAt": now.isoformat(),
-        "totalMovies": total_movies,
-        "newArrivals": json_movies
-    }
-    
+
+    json_data = {"generatedAt": now.isoformat(), "totalMovies": total_movies, "newArrivals": json_movies}
+
     # Ensure tmp dir exists
     json_output_file.parent.mkdir(parents=True, exist_ok=True)
-    
-    with open(json_output_file, 'w', encoding='utf-8') as f:
+
+    with open(json_output_file, "w", encoding="utf-8") as f:
         json.dump(json_data, f, indent=2, ensure_ascii=False)
-    
+
     print("Done.")
 
 
 def main():
     import argparse
+
     parser = argparse.ArgumentParser(description="Generate weekly digest.")
     parser.add_argument("--input", type=Path, default=INPUT_FILE, help="Path to input films.json")
     parser.add_argument("--output", type=Path, default=OUTPUT_FILE, help="Path to output Markdown/JSON file")
-    
+
     args = parser.parse_args()
-    
+
     generate_digest(args.input, args.output)
 
 

--- a/backend/metadata_utils.py
+++ b/backend/metadata_utils.py
@@ -35,6 +35,7 @@ def redact_secrets(text: Any, secrets: Iterable[Optional[str]]) -> str:
 @dataclass
 class ExternalMetadataResult:
     """Result returned by an external metadata provider."""
+
     imdb_id: Optional[str] = None
     imdb_url: Optional[str] = None
     tmdb_id: Optional[str] = None
@@ -45,7 +46,7 @@ class ExternalMetadataResult:
     # Rating data from provider
     vote_average: Optional[float] = None
     vote_count: Optional[int] = None
-    
+
     # Verification / Evaluation Data
     matched_title: Optional[str] = None
     matched_original_title: Optional[str] = None
@@ -53,6 +54,7 @@ class ExternalMetadataResult:
     matched_directors: List[str] = None
     match_score: int = 0
     match_details: dict = None  # To store raw discrepancies (year delta, score breakdown)
+
 
 class TitleNormalizer:
     """Utilities for normalizing titles and generating spelling variants."""
@@ -142,7 +144,7 @@ class TitleNormalizer:
             if word in lower_title:
                 # Use regex for case-insensitive replacement while preserving case of match
                 pattern = re.compile(re.escape(word), re.IGNORECASE)
-                
+
                 def replace_case_match(match):
                     g = match.group()
                     if g.isupper():
@@ -152,7 +154,7 @@ class TitleNormalizer:
                     return replacement
 
                 new_title = pattern.sub(replace_case_match, title)
-                
+
                 # Verify we actually changed something and it's not effectively same
                 if new_title.lower() != title.lower() and new_title not in alternatives:
                     alternatives.append(new_title)
@@ -170,11 +172,11 @@ class TitleNormalizer:
             r"Redux",
             r"\[MV\]",  # Music Video
         ]
-        
+
         cleaned = title
         for pattern in patterns:
             cleaned = re.sub(pattern, "", cleaned, flags=re.IGNORECASE)
-            
+
         return re.sub(r"\s+", " ", cleaned).strip()
 
     def generate_title_variants(
@@ -186,10 +188,10 @@ class TitleNormalizer:
         variants: List[str] = []
 
         normalized_title = title.strip()
-        
+
         # 1. Original MUBI title
         variants.append(normalized_title)
-        
+
         # 2. Original title (from metadata)
         if original_title and original_title.strip().lower() != normalized_title.lower():
             variants.append(original_title.strip())
@@ -245,16 +247,16 @@ class RetryStrategy:
                 result = func()
                 if result.success:
                     return result
-                
-                # If explicitly failed without exception (e.g. not found), we might still want to retry 
+
+                # If explicitly failed without exception (e.g. not found), we might still want to retry
                 # if the logic was purely connection based, but here we assume logic decided valid 'not found'.
                 # However, for 429 logic below, it's inside exception block.
                 # If logic returns result.success=False for "Not Found", verify if we should retry?
                 # Usually "Not Found" is final. Rate limts raise HTTPError.
                 if result.error_message == "Title not found (404)":
-                     return result
+                    return result
 
-                # If result is failure but not 404, loop might continue? 
+                # If result is failure but not 404, loop might continue?
                 # Current implementation just returns result if not success??
                 # Wait, original code:
                 # if result.success: return result
@@ -264,10 +266,10 @@ class RetryStrategy:
 
             except requests.exceptions.HTTPError as error:
                 status_code = error.response.status_code if error.response else None
-                if status_code in [401, 402, 429, 500, 502, 503, 504]: # Added 5xx for safer server error handling
+                if status_code in [401, 402, 429, 500, 502, 503, 504]:  # Added 5xx for safer server error handling
                     retry_after = error.response.headers.get("Retry-After")
                     wait_time = backoff
-                    
+
                     if retry_after:
                         try:
                             wait_time = float(retry_after) + 1  # Add small buffer
@@ -279,14 +281,14 @@ class RetryStrategy:
                     time.sleep(wait_time)
                     backoff *= self.multiplier
                     continue
-                
+
                 if status_code == 404:
                     logger.debug(f"Title '{title}' not found (404)")
                     return ExternalMetadataResult(
                         success=False,
                         error_message="Title not found (404)",
                     )
-                
+
                 logger.error(f"HTTP error {status_code}: {redact_secrets(error, self.secrets)}")
                 return ExternalMetadataResult(
                     success=False,

--- a/backend/metadata_utils.py
+++ b/backend/metadata_utils.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import logging
 import re
 import time
-import logging
-from typing import Callable, Iterable, List, Optional, Any
 from dataclasses import dataclass
+from typing import Any, Callable, Iterable, List, Optional
 from urllib.parse import quote, quote_plus
+
 import requests
 
 # Configure logging

--- a/backend/omdb_provider.py
+++ b/backend/omdb_provider.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import logging
 import itertools
+import logging
 import threading
-from typing import Any, Dict, Optional, List, Union
+from typing import Any, Dict, List, Union
+
 import requests
 
 from .external_urls import OMDB_API_URL

--- a/backend/omdb_provider.py
+++ b/backend/omdb_provider.py
@@ -13,6 +13,7 @@ from .metadata_utils import ExternalMetadataResult, RetryStrategy, redact_secret
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
 class OMDBProvider:
     """
     OMDB metadata provider.
@@ -20,9 +21,9 @@ class OMDBProvider:
     using an existing IMDB ID.
     Supports API key rotation.
     """
-    
+
     BASE_URL = OMDB_API_URL
-    
+
     def __init__(self, api_keys: Union[str, List[str]]) -> None:
         """
         Initialize OMDB provider with one or more API keys.
@@ -31,26 +32,26 @@ class OMDBProvider:
         if isinstance(api_keys, str):
             self.api_keys = [api_keys]
         else:
-            self.api_keys = [k for k in api_keys if k] # Filter empty strings
-            
+            self.api_keys = [k for k in api_keys if k]  # Filter empty strings
+
         if not self.api_keys:
             raise ValueError("At least one OMDB API key must be provided.")
-            
+
         self._key_cycle = itertools.cycle(self.api_keys)
         self._bad_keys = set()
         self._lock = threading.Lock()
-        
+
         self.retry_strategy = RetryStrategy(
             max_retries=3,
             initial_backoff=1.0,
             multiplier=1.5,
             secrets=self.api_keys,
         )
-        
+
     @property
     def provider_name(self) -> str:
         return "OMDB"
-        
+
     def _get_next_key(self) -> str:
         with self._lock:
             # Try to find a non-bad key
@@ -62,74 +63,73 @@ class OMDBProvider:
             # If all are bad, raise exception to stop trying
             if len(self._bad_keys) >= len(self.api_keys):
                 raise Exception("All OMDB API keys are marked as bad.")
-            
+
             return k
-            
+
     def _mark_key_bad(self, key: str):
         with self._lock:
             self._bad_keys.add(key)
-    
+
     def get_details(self, imdb_id: str) -> ExternalMetadataResult:
         """
         Fetch details from OMDB using IMDB ID.
         Retries with valid keys if a 401 Invalid Key error occurs.
         """
-        
+
         # We allow trying up to the number of keys we have + 1 (for good measure)
         # to ensure we cycle through all potential candidates if needed.
         max_attempts = len(self.api_keys) + 1
-        
+
         last_error = None
-        
+
         for attempt in range(max_attempts):
             current_key = self._get_next_key()
-            
-            params = {
-                "apikey": current_key,
-                "i": imdb_id,
-                "plot": "short",
-                "r": "json"
-            }
-            
+
+            params = {"apikey": current_key, "i": imdb_id, "plot": "short", "r": "json"}
+
             headers = {
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
             }
-            
+
             try:
                 response = requests.get(self.BASE_URL, params=params, headers=headers, timeout=10)
-                
+
                 # Check directly for 401 (Invalid Key)
                 if response.status_code == 401:
-                    logger.warning(f"OMDB: Key ending in ...{current_key[-4:]} failed (401 Unauthorized). Response: {response.text.strip()}. Marking as bad.")
+                    logger.warning(
+                        f"OMDB: Key ending in ...{current_key[-4:]} failed (401 Unauthorized). Response: {response.text.strip()}. Marking as bad."
+                    )
                     self._mark_key_bad(current_key)
                     last_error = f"401 Unauthorized: {response.text.strip()}"
-                    continue # Retry loop will get a new key
-                
+                    continue  # Retry loop will get a new key
+
                 # Check for 403 (Forbidden - sometimes used for limits)
                 if response.status_code == 403:
-                    logger.warning(f"OMDB: Key ending in ...{current_key[-4:]} failed (403 Forbidden). Response: {response.text.strip()}. Marking as bad.")
+                    logger.warning(
+                        f"OMDB: Key ending in ...{current_key[-4:]} failed (403 Forbidden). Response: {response.text.strip()}. Marking as bad."
+                    )
                     self._mark_key_bad(current_key)
                     last_error = f"403 Forbidden: {response.text.strip()}"
                     continue
-                
+
                 response.raise_for_status()
                 data = response.json()
-                
+
                 if data.get("Response") != "True":
                     error_msg = data.get("Error", "Unknown error")
                     # Some OMDB errors (like "Request limit reached!") might simpler be handled by rotation too?
                     # But "Movie not found" should NOT rotate.
                     if "limit" in error_msg.lower():
-                        logger.warning(f"OMDB: Limit reached for key ending in ...{current_key[-4:]}. Removing from rotation.")
+                        logger.warning(
+                            f"OMDB: Limit reached for key ending in ...{current_key[-4:]}. Removing from rotation."
+                        )
                         self._mark_key_bad(current_key)
                         continue
-                        
+
                     return ExternalMetadataResult(
-                        success=False, 
-                        source_provider=self.provider_name,
-                        error_message=error_msg
+                        success=False, source_provider=self.provider_name, error_message=error_msg
                     )
-                 
+
                 # Success - Parse Data
                 return self._parse_response(data, imdb_id)
 
@@ -140,25 +140,25 @@ class OMDBProvider:
                 if "All OMDB API keys are marked as bad" in safe_error:
                     logger.warning(f"OMDB: Aborting request. {safe_error}")
                     last_error = safe_error
-                    break 
-                
+                    break
+
                 logger.warning(f"OMDB: Network error with key ...{current_key[-4:]}: {safe_error}")
                 last_error = safe_error
                 # For network errors, we might want to just retry (maybe same key, maybe next).
                 # Continuing loop rotates key, which is fine.
                 continue
-                
+
         # If we exit loop, we failed
         return ExternalMetadataResult(
             success=False,
             source_provider=self.provider_name,
-            error_message=f"Exhausted all API keys. Last error: {last_error}"
+            error_message=f"Exhausted all API keys. Last error: {last_error}",
         )
 
     def _parse_response(self, data: Dict[str, Any], imdb_id: str) -> ExternalMetadataResult:
         """Helper to parse valid OMDB JSON response."""
-        ratings_data = [] 
-        
+        ratings_data = []
+
         def parse_votes(v_str):
             try:
                 return int(v_str.replace(",", ""))
@@ -170,57 +170,41 @@ class OMDBProvider:
             try:
                 score = float(data["imdbRating"])
                 votes = parse_votes(data.get("imdbVotes", "0"))
-                ratings_data.append({
-                    "source": "imdb",
-                    "score_over_10": score,
-                    "voters": votes
-                })
+                ratings_data.append({"source": "imdb", "score_over_10": score, "voters": votes})
             except ValueError:
                 pass
-        
+
         # 2. Other Ratings
         for r in data.get("Ratings", []):
             source_name = r.get("Source")
             value = r.get("Value")
-            
+
             if source_name == "Internet Movie Database":
-                continue 
-            
+                continue
+
             elif source_name == "Rotten Tomatoes":
                 try:
                     percentage = int(value.replace("%", ""))
                     score = percentage / 10.0
-                    ratings_data.append({
-                        "source": "rotten_tomatoes",
-                        "score_over_10": score,
-                        "voters": 0
-                    })
+                    ratings_data.append({"source": "rotten_tomatoes", "score_over_10": score, "voters": 0})
                 except ValueError:
                     pass
-                    
+
             elif source_name == "Metacritic":
                 try:
                     raw_score = int(value.split("/")[0])
                     score = raw_score / 10.0
-                    ratings_data.append({
-                        "source": "metacritic",
-                        "score_over_10": score,
-                        "voters": 0
-                    })
+                    ratings_data.append({"source": "metacritic", "score_over_10": score, "voters": 0})
                 except (ValueError, IndexError):
                     pass
 
-        result = ExternalMetadataResult(
-            success=True,
-            source_provider=self.provider_name,
-            imdb_id=imdb_id
-        )
+        result = ExternalMetadataResult(success=True, source_provider=self.provider_name, imdb_id=imdb_id)
         result.extra_ratings = ratings_data
         return result
 
     def test_connection(self) -> bool:
         """Test connection (using a known ID)."""
-        res = self.get_details("tt0111161") # Shawshank Redemption
+        res = self.get_details("tt0111161")  # Shawshank Redemption
         return res.success
 
     def get_failed_keys(self) -> List[str]:

--- a/backend/rating_calculator.py
+++ b/backend/rating_calculator.py
@@ -4,13 +4,14 @@ from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+
 class BayesianRatingCalculator:
     """
     Calculates composite ratings using a Bayesian Average.
-    
+
     Formula:
     W = (v / (v + m)) * R + (m / (v + m)) * C
-    
+
     Where:
     W = Weighted Rating
     R = Average computed Rating for the item (Mean of scores from sources)
@@ -18,29 +19,30 @@ class BayesianRatingCalculator:
     m = Minimum votes required (Confidence Threshold, derived from Mubi avg votes)
     C = Global Mean vote across the whole report
     """
-    
+
     DEFAULT_C = 6.9
-    
+
     def __init__(self, films_path: str, history_path: Optional[str] = None):
         self.films_path = films_path
         self.history_path = history_path
         self.data: Dict[str, Any] = {}
         self.items: List[Dict[str, Any]] = []
         self.bayes_stats: Dict[str, float] = {}
-        
+
     def load_data(self):
-        with open(self.films_path, 'r', encoding='utf-8') as f:
+        with open(self.films_path, "r", encoding="utf-8") as f:
             self.data = json.load(f)
-        self.items = self.data.get('items', [])
-        
+        self.items = self.data.get("items", [])
+
         # Load existing stats if available (Warm Start)
         # Priority 1: Current file (if it has stats)
         # Priority 2: History file (if provided)
-        if self.data.get('bayes_stats'):
-             self.bayes_stats = self.data.get('bayes_stats')
-             logger.info(f"Warm Start: Found stats in current file: {self.bayes_stats}")
+        if self.data.get("bayes_stats"):
+            self.bayes_stats = self.data.get("bayes_stats")
+            logger.info(f"Warm Start: Found stats in current file: {self.bayes_stats}")
         elif self.history_path:
             import os
+
             logger.info(f"Attempting Warm Start from history file: {self.history_path}")
             if not os.path.exists(self.history_path):
                 logger.error(f"DEBUG: History file path '{self.history_path}' does NOT exist.")
@@ -48,32 +50,32 @@ class BayesianRatingCalculator:
             else:
                 try:
                     logger.info(f"DEBUG: Opening history file at {os.path.abspath(self.history_path)}")
-                    with open(self.history_path, 'r', encoding='utf-8') as f:
+                    with open(self.history_path, "r", encoding="utf-8") as f:
                         hist_data = json.load(f)
-                        
+
                     keys = list(hist_data.keys())
                     logger.info(f"DEBUG: History file keys: {keys}")
-                    
-                    if 'bayes_stats' in hist_data:
-                        self.bayes_stats = hist_data.get('bayes_stats', {})
+
+                    if "bayes_stats" in hist_data:
+                        self.bayes_stats = hist_data.get("bayes_stats", {})
                         logger.info(f"DEBUG: Successfully loaded history stats: {self.bayes_stats}")
                     else:
                         logger.warning("DEBUG: 'bayes_stats' key missing in history file!")
                         self.bayes_stats = {}
-                        
+
                 except Exception as e:
                     logger.warning(f"Failed to load history file: {e}. Proceeding with Cold Start.")
                     self.bayes_stats = {}
         else:
-             logger.info("No history file provided. Cold Start.")
-             self.bayes_stats = {}
-        
+            logger.info("No history file provided. Cold Start.")
+            self.bayes_stats = {}
+
     def save_data(self):
-        self.data['items'] = self.items
-        self.data['bayes_stats'] = self.bayes_stats
-        with open(self.films_path, 'w', encoding='utf-8') as f:
+        self.data["items"] = self.items
+        self.data["bayes_stats"] = self.bayes_stats
+        with open(self.films_path, "w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2, ensure_ascii=False)
-            
+
     def get_constants(self) -> Tuple[float, float]:
         """
         Determine C (Global Mean) and m (Confidence Threshold).
@@ -81,38 +83,41 @@ class BayesianRatingCalculator:
         - Cold Start: Use Default C, Calculate m from current Mubi votes.
         - Warm Start: Use stored C and m.
         """
-        c_val = self.bayes_stats.get('global_mean_C')
-        m_val = self.bayes_stats.get('mubi_confidence_m')
-        
+        c_val = self.bayes_stats.get("global_mean_C")
+        m_val = self.bayes_stats.get("mubi_confidence_m")
+
         if c_val is not None and m_val is not None:
             logger.info(f"Warm Start: Using stored constants C={c_val}, m={m_val}")
             return c_val, m_val
-            
+
         logger.info("Cold Start: Calculating initial constants...")
         # Start with default C
         c_val = self.DEFAULT_C
-        
+
         # Calculate m from Mubi votes (Use Median)
         mubi_votes_list = []
         for item in self.items:
-            mubi_rating = self._get_rating_by_source(item, 'mubi')
+            mubi_rating = self._get_rating_by_source(item, "mubi")
             if mubi_rating:
-                votes = mubi_rating.get('voters', 0)
+                votes = mubi_rating.get("voters", 0)
                 mubi_votes_list.append(votes)
-                
+
         if mubi_votes_list:
             import statistics
+
             m_val = statistics.median(mubi_votes_list)
         else:
             m_val = 0
-        
-        logger.info(f"Cold Start: Calculated m={m_val} (Median of {len(mubi_votes_list)} films), using Default C={c_val}")
+
+        logger.info(
+            f"Cold Start: Calculated m={m_val} (Median of {len(mubi_votes_list)} films), using Default C={c_val}"
+        )
         return c_val, m_val
 
     def _get_rating_by_source(self, item: Dict[str, Any], source: str) -> Optional[Dict[str, Any]]:
-        ratings = item.get('ratings', [])
+        ratings = item.get("ratings", [])
         for r in ratings:
-            if r.get('source') == source:
+            if r.get("source") == source:
                 return r
         return None
 
@@ -120,32 +125,32 @@ class BayesianRatingCalculator:
         """
         Calculate R (Raw Average) and v (Total Votes) from all sources.
         """
-        ratings = item.get('ratings', [])
+        ratings = item.get("ratings", [])
         if not ratings:
             return 0.0, 0
-            
+
         total_weighted_score = 0.0
         total_votes = 0
-        
+
         for r in ratings:
             # Skip existing bayesian ratings to avoid double counting / recursion
-            if r.get('source') == 'bayesian':
+            if r.get("source") == "bayesian":
                 continue
 
             try:
-                score = float(r.get('score_over_10', 0))
-                votes = int(r.get('voters', 0))
-                
+                score = float(r.get("score_over_10", 0))
+                votes = int(r.get("voters", 0))
+
                 # Exclude invalid data (0 votes usually means no data for aggregation purposes)
                 if votes > 0:
-                    total_weighted_score += (score * votes)
+                    total_weighted_score += score * votes
                     total_votes += votes
             except (ValueError, TypeError):
                 continue
-                
+
         if total_votes == 0:
             return 0.0, 0
-            
+
         raw_average = total_weighted_score / total_votes
         return raw_average, total_votes
 
@@ -158,95 +163,90 @@ class BayesianRatingCalculator:
         total_r_raw = 0.0
         count_r = 0
         count_mubi = 0
-        
+
         all_mubi_votes = []
-        
+
         for item in self.items:
             # Re-calculate these on the fly or could assume they are fresh
             r_raw, _ = self.calculate_raw_metrics(item)
             if r_raw > 0:
                 total_r_raw += r_raw
                 count_r += 1
-                
-            mubi_rating = self._get_rating_by_source(item, 'mubi')
+
+            mubi_rating = self._get_rating_by_source(item, "mubi")
             if mubi_rating:
-                 votes = mubi_rating.get('voters', 0)
-                 all_mubi_votes.append(votes)
-                 count_mubi += 1
-        
+                votes = mubi_rating.get("voters", 0)
+                all_mubi_votes.append(votes)
+                count_mubi += 1
+
         new_c = total_r_raw / count_r if count_r > 0 else self.DEFAULT_C
-        
+
         # Use Median for m to avoid skew from blockbusters
         if all_mubi_votes:
             import statistics
+
             new_m = statistics.median(all_mubi_votes)
         else:
             new_m = 0.0
-        
+
         return new_c, new_m
 
     def run(self):
         self.load_data()
-        
+
         C, m = self.get_constants()
-        
+
         updated_count = 0
         for item in self.items:
             R_raw, v_total = self.calculate_raw_metrics(item)
-            
+
             if v_total == 0:
                 # Remove any stale bayesian rating
-                item['ratings'] = [r for r in item.get('ratings', []) if r.get('source') != 'bayesian']
-                # Optionally add a 0-value rating or just skip. 
+                item["ratings"] = [r for r in item.get("ratings", []) if r.get("source") != "bayesian"]
+                # Optionally add a 0-value rating or just skip.
                 # User prompted "bayesian rating can just be one of the rating", usually 0 votes means no rating object.
                 # Let's skip adding it if 0 votes, but ensure cleanup.
-                item.pop('bayesian_rating', None)
-                item.pop('total_votes', None)
+                item.pop("bayesian_rating", None)
+                item.pop("total_votes", None)
                 continue
-            
+
             # Bayesian Formula
             # W = (v / (v + m)) * R + (m / (v + m)) * C
             weight_v = v_total / (v_total + m)
             weight_m = m / (v_total + m)
-            
+
             W = (weight_v * R_raw) + (weight_m * C)
-            
+
             # Remove existing bayesian rating if present
-            item['ratings'] = [r for r in item.get('ratings', []) if r.get('source') != 'bayesian']
-            
+            item["ratings"] = [r for r in item.get("ratings", []) if r.get("source") != "bayesian"]
+
             # Add new bayesian rating
-            item['ratings'].append({
-                "source": "bayesian",
-                "score_over_10": round(W, 1),
-                "voters": v_total
-            })
-            
+            item["ratings"].append({"source": "bayesian", "score_over_10": round(W, 1), "voters": v_total})
+
             # Legacy field cleanup (if we want to ensure they are gone, though schema validation might strip them)
-            item.pop('bayesian_rating', None)
-            item.pop('total_votes', None)
-            
+            item.pop("bayesian_rating", None)
+            item.pop("total_votes", None)
+
             updated_count += 1
-            
+
         # Update calibration for next run
         new_c, new_m = self.calculate_new_constants()
-        self.bayes_stats = {
-            "global_mean_C": round(new_c, 2),
-            "mubi_confidence_m": round(new_m, 2)
-        }
-        
+        self.bayes_stats = {"global_mean_C": round(new_c, 2), "mubi_confidence_m": round(new_m, 2)}
+
         logger.info(f"Bayesian Rating Compete. Processed {len(self.items)} items. New Stats: {self.bayes_stats}")
         self.save_data()
 
+
 if __name__ == "__main__":
     import argparse
-    
+
     logging.basicConfig(level=logging.INFO)
-    
+
     parser = argparse.ArgumentParser(description="Bayesian Rating Calculator")
-    parser.add_argument('films_path', help="Path to films.json")
-    parser.add_argument('--history-file', help="Path to previous films.json for warm start stats", default=None)
-    
+    parser.add_argument("films_path", help="Path to films.json")
+    parser.add_argument("--history-file", help="Path to previous films.json for warm start stats", default=None)
+
     args = parser.parse_args()
-        
+
     calc = BayesianRatingCalculator(args.films_path, history_path=args.history_file)
     calc.run()

--- a/backend/rating_calculator.py
+++ b/backend/rating_calculator.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import List, Dict, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +156,6 @@ class BayesianRatingCalculator:
         m = Average of Mubi votes
         """
         total_r_raw = 0.0
-        total_mubi_votes = 0
         count_r = 0
         count_mubi = 0
         
@@ -239,7 +238,6 @@ class BayesianRatingCalculator:
         self.save_data()
 
 if __name__ == "__main__":
-    import sys
     import argparse
     
     logging.basicConfig(level=logging.INFO)

--- a/backend/scraper.py
+++ b/backend/scraper.py
@@ -1,15 +1,14 @@
-import requests
-import sys
-import json
-import time
-import os
-import gzip
-import hashlib
 import concurrent.futures
+import json
 import logging
-import pycountry
+import os
 import random
+import sys
+import time
 from datetime import datetime
+
+import pycountry
+import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -382,7 +381,7 @@ class MubiScraper:
             except Exception as e:
                 logger.error(f"Failed to load existing series data: {e}")
         else:
-             logger.info(f"No existing series data found. Starting fresh.")
+             logger.info("No existing series data found. Starting fresh.")
 
 
         # -- 2. DETERMINE TARGETS --

--- a/backend/scraper.py
+++ b/backend/scraper.py
@@ -18,17 +18,18 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from backend.external_urls import MUBI_API_V4_URL, MUBI_WEB_URL
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
 
 class MubiScraper:
     BASE_URL = MUBI_API_V4_URL
-    UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0'
+    UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0"
     MIN_TOTAL_FILMS = 1000
-    MAX_WORKERS = 2 # Increased for debugging speed
-    CRITICAL_COUNTRIES = ['US', 'GB', 'FR', 'DE']
-    MAX_MISSING_PERCENT = 5.0 # Max % of films allowed to have missing critical fields before failure
-    
+    MAX_WORKERS = 2  # Increased for debugging speed
+    CRITICAL_COUNTRIES = ["US", "GB", "FR", "DE"]
+    MAX_MISSING_PERCENT = 5.0  # Max % of films allowed to have missing critical fields before failure
+
     # Dynamically generate full country list
     COUNTRIES = [country.alpha_2 for country in pycountry.countries]
 
@@ -47,7 +48,7 @@ class MubiScraper:
         "MATURE": "R",
         "18": "NC-17",
         "A18": "NC-17",
-        "ADULT": "NC-17"
+        "ADULT": "NC-17",
     }
 
     def __init__(self):
@@ -56,78 +57,73 @@ class MubiScraper:
     def _create_session(self):
         session = requests.Session()
         retries = Retry(
-            total=8, # Increased retries
-            backoff_factor=2, # Increased backoff
+            total=8,  # Increased retries
+            backoff_factor=2,  # Increased backoff
             status_forcelist=[500, 502, 503, 504, 429],
-            allowed_methods=["GET"]
+            allowed_methods=["GET"],
         )
         adapter = HTTPAdapter(max_retries=retries)
-        session.mount('https://', adapter)
-        session.mount('http://', adapter)
-        session.headers.update({
-            'User-Agent': self.UA,
-            'Client': 'web',
-            'Origin': MUBI_WEB_URL,
-            'Referer': MUBI_WEB_URL,
-            'Accept-Encoding': 'gzip'
-        })
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        session.headers.update(
+            {
+                "User-Agent": self.UA,
+                "Client": "web",
+                "Origin": MUBI_WEB_URL,
+                "Referer": MUBI_WEB_URL,
+                "Accept-Encoding": "gzip",
+            }
+        )
         return session
 
     def _get_headers(self, country_code):
-        headers = {
-            'Client-Country': country_code,
-            'accept-language': 'en'
-        }
+        headers = {"Client-Country": country_code, "accept-language": "en"}
         return headers
 
     def fetch_films_for_country(self, country_code):
         # Add random jitter to desynchronize threads
         time.sleep(random.uniform(0.5, 2.0))
-        
+
         logger.info(f"Fetching films for {country_code}...")
         film_ids = set()
-        films_data = [] # List of film objects
+        films_data = []  # List of film objects
         page = 1
-        
+
         while True:
             try:
                 url = f"{self.BASE_URL}/browse/films"
-                params = {
-                    'page': page,
-                    'sort': 'title',
-                    'playable': 'true'
-                }
-                
+                params = {"page": page, "sort": "title", "playable": "true"}
+
                 response = self.session.get(url, headers=self._get_headers(country_code), params=params, timeout=15)
-                
+
                 if response.status_code == 429:
-                    retry_after = int(response.headers.get('Retry-After', 10))
+                    retry_after = int(response.headers.get("Retry-After", 10))
                     logger.warning(f"Rate limited (429). Waiting {retry_after}s...")
                     time.sleep(retry_after)
                     continue
 
                 response.raise_for_status()
                 data = response.json()
-                
-                films = data.get('films', [])
+
+                films = data.get("films", [])
                 for film in films:
-                    film_ids.add(film['id'])
+                    film_ids.add(film["id"])
                     films_data.append(film)
 
-                meta = data.get('meta', {})
+                meta = data.get("meta", {})
                 logger.info(f"[{country_code}] Page {page} fetched. {len(films)} films.")
 
-                if not meta.get('next_page'):
+                if not meta.get("next_page"):
                     break
-                
-                page = meta['next_page']
-                time.sleep(0.5) # Politeness delay between pages
+
+                page = meta["next_page"]
+                time.sleep(0.5)  # Politeness delay between pages
 
             except Exception as e:
                 logger.error(f"Error fetching page {page} for {country_code}: {e}")
                 # Re-raise so run() can track the error
                 raise e
-        
+
         return films_data
 
     def validate_data(self, final_items):
@@ -146,26 +142,28 @@ class MubiScraper:
         missing_mubi_id = 0
         missing_title = 0
         missing_year = 0
-        
+
         for item in final_items:
-            if not item.get('mubi_id'):
+            if not item.get("mubi_id"):
                 missing_mubi_id += 1
                 logger.warning(f"Film missing mubi_id: {item}")
-            if not item.get('title'):
+            if not item.get("title"):
                 missing_title += 1
-            if not item.get('year'):
+            if not item.get("year"):
                 missing_year += 1
-        
+
         # Calculate percentages
         if total > 0:
             pct_missing_year = (missing_year / total) * 100
             if pct_missing_year > self.MAX_MISSING_PERCENT:
-                validation_errors.append(f"Field Integrity: {pct_missing_year:.1f}% of films missing 'year' (max {self.MAX_MISSING_PERCENT}%)")
-            
+                validation_errors.append(
+                    f"Field Integrity: {pct_missing_year:.1f}% of films missing 'year' (max {self.MAX_MISSING_PERCENT}%)"
+                )
+
             if missing_title > 0:
-                 pct_missing_title = (missing_title / total) * 100
-                 if pct_missing_title > self.MAX_MISSING_PERCENT:
-                     validation_errors.append(f"Field Integrity: {pct_missing_title:.1f}% of films missing 'title'")
+                pct_missing_title = (missing_title / total) * 100
+                if pct_missing_title > self.MAX_MISSING_PERCENT:
+                    validation_errors.append(f"Field Integrity: {pct_missing_title:.1f}% of films missing 'title'")
 
         return validation_errors
 
@@ -175,56 +173,60 @@ class MubiScraper:
         needed to cover all films in the existing dataset.
         """
         logger.info("Calculating optimal country set using Greedy Set Cover...")
-        
+
         # 1. Build Universe and Subsets
         # Universe: All Film IDs we need to cover
         universe = set()
         # Subsets: Country -> Set of Film IDs available there
         country_coverage = {c: set() for c in self.COUNTRIES}
-        
+
         for film in existing_films:
-            fid = film['mubi_id']
+            fid = film["mubi_id"]
             universe.add(fid)
-            
+
             # Use available_countries keys
-            available_countries = film.get('available_countries', {})
+            available_countries = film.get("available_countries", {})
             for c in available_countries.keys():
                 if c in country_coverage:
                     country_coverage[c].add(fid)
-        
+
         logger.info(f"Universe size: {len(universe)} films across {len(self.COUNTRIES)} countries.")
-        
+
         # 2. Greedy Loop
         selected_countries = []
         covered_films = set()
-        
+
         while len(covered_films) < len(universe):
             # Find country that covers the most *uncovered* films
             best_country = None
             best_new_coverage = 0
-            
+
             remaining_needed = universe - covered_films
-            
+
             for country, films in country_coverage.items():
                 if country in selected_countries:
                     continue
-                
+
                 # Intersection of this country's films with what we still need
                 newly_covered = len(films.intersection(remaining_needed))
-                
+
                 if newly_covered > best_new_coverage:
                     best_new_coverage = newly_covered
                     best_country = country
-            
+
             if best_country is None:
                 # This happens if remaining films are not available in any known country (should not happen if data is consistent)
-                logger.warning(f"Could not find coverage for {len(remaining_needed)} remaining films. Stopping greedy search.")
+                logger.warning(
+                    f"Could not find coverage for {len(remaining_needed)} remaining films. Stopping greedy search."
+                )
                 break
-            
+
             selected_countries.append(best_country)
             covered_films.update(country_coverage[best_country])
-            logger.info(f"Selected {best_country} (Covers {best_new_coverage} new films). Total covered: {len(covered_films)}/{len(universe)}")
-            
+            logger.info(
+                f"Selected {best_country} (Covers {best_new_coverage} new films). Total covered: {len(covered_films)}/{len(universe)}"
+            )
+
         logger.info(f"Optimal set found: {len(selected_countries)} countries cover {len(covered_films)} films.")
         # Sort for consistent execution order
         return sorted(selected_countries)
@@ -234,20 +236,31 @@ class MubiScraper:
         Removes specific fields from series/episode data to reduce file size.
         """
         keys_to_remove = [
-            'fotd_show_episode', 'episode_label_color', 'title_upcase', 'slug', 'web_url',
-            'availability_message', 'short_synopsis_html', 'default_editorial_html',
-            'trailer_url', 'trailer_id', 'industry_events_count', 'cast_members_count',
-            'optimised_trailers', 'artworks'
+            "fotd_show_episode",
+            "episode_label_color",
+            "title_upcase",
+            "slug",
+            "web_url",
+            "availability_message",
+            "short_synopsis_html",
+            "default_editorial_html",
+            "trailer_url",
+            "trailer_id",
+            "industry_events_count",
+            "cast_members_count",
+            "optimised_trailers",
+            "artworks",
         ]
-        
+
         # Helper to prune a dict in-place
         def prune_dict(d):
-            if not d: return
+            if not d:
+                return
             for key in keys_to_remove:
                 d.pop(key, None)
-        
-        prune_dict(data.get('episode'))
-        prune_dict(data.get('series'))
+
+        prune_dict(data.get("episode"))
+        prune_dict(data.get("series"))
 
     def _prune_film_data(self, data):
         """
@@ -255,48 +268,56 @@ class MubiScraper:
         Removes: label_hex_color from content_rating, focal_point from artworks.
         """
         # Prune content_rating
-        content_rating = data.get('content_rating')
+        content_rating = data.get("content_rating")
         if content_rating and isinstance(content_rating, dict):
-            content_rating.pop('label_hex_color', None)
-        
+            content_rating.pop("label_hex_color", None)
+
         # Prune artworks
-        artworks = data.get('artworks', [])
+        artworks = data.get("artworks", [])
         if artworks:
             # Prune unused artwork formats to save space
             # We only keep:
             # - cover_artwork_vertical (Poster)
             # - centered_background (Fanart)
             # - cover_artwork_horizontal (Banner)
-            
-            kept_formats = {
-                'cover_artwork_vertical', 
-                'centered_background', 
-                'cover_artwork_horizontal'
-            }
-            
+
+            kept_formats = {"cover_artwork_vertical", "centered_background", "cover_artwork_horizontal"}
+
             pruned_artworks = []
             for artwork in artworks:
-                if artwork.get('format') in kept_formats:
+                if artwork.get("format") in kept_formats:
                     # Prune extra fields from the artwork object itself
-                    if 'focal_point' in artwork:
-                        del artwork['focal_point']
-                    if 'locale' in artwork: # Often null or unused
-                         del artwork['locale']
+                    if "focal_point" in artwork:
+                        del artwork["focal_point"]
+                    if "locale" in artwork:  # Often null or unused
+                        del artwork["locale"]
                     pruned_artworks.append(artwork)
-            
-            data['artworks'] = pruned_artworks
+
+            data["artworks"] = pruned_artworks
 
     def _enrich_genres(self, film_data):
         """
         Enriches genres with 'LGBTQ+' if keywords are found in synopsis or editorial.
         """
-        keys_to_check = ['short_synopsis', 'default_editorial']
+        keys_to_check = ["short_synopsis", "default_editorial"]
         keywords = [
-            'queer', 'lgbt', 'lesbian', 'transgender', 'bisexual', 'intersex', 
-            'pansexual', 'transsexual', 'non-binary', 'nonbinary', 'homosexual', 
-            'drag queen', 'drag king', 'same-sex', 'gender identity'
+            "queer",
+            "lgbt",
+            "lesbian",
+            "transgender",
+            "bisexual",
+            "intersex",
+            "pansexual",
+            "transsexual",
+            "non-binary",
+            "nonbinary",
+            "homosexual",
+            "drag queen",
+            "drag king",
+            "same-sex",
+            "gender identity",
         ]
-        
+
         found = False
         for key in keys_to_check:
             text = film_data.get(key)
@@ -308,218 +329,217 @@ class MubiScraper:
                         break
             if found:
                 break
-        
-        if found:
-            genres = film_data.get('genres') or []
-            if 'LGBTQ+' not in genres:
-                genres.append('LGBTQ+')
-                film_data['genres'] = genres
 
-    def run(self, output_path='films.json', series_path='series.json', mode='deep', input_path=None):
-        all_films = {} # id -> film_data
-        all_series = {} # id -> series_data
-        film_countries = {} # id -> dict(country -> consumable)
-        series_countries = {} # id -> dict(country -> consumable)
-        errors = [] # Track errors per country
-        
+        if found:
+            genres = film_data.get("genres") or []
+            if "LGBTQ+" not in genres:
+                genres.append("LGBTQ+")
+                film_data["genres"] = genres
+
+    def run(self, output_path="films.json", series_path="series.json", mode="deep", input_path=None):
+        all_films = {}  # id -> film_data
+        all_series = {}  # id -> series_data
+        film_countries = {}  # id -> dict(country -> consumable)
+        series_countries = {}  # id -> dict(country -> consumable)
+        errors = []  # Track errors per country
+
         # Determine paths
         # If input_path is not explicitly set, try to use output_path as input (incremental update)
         load_path = input_path if input_path else output_path
         # We also need to load existing series data if available (simplification: assume input_path holds films, we derive series input path)
-        series_load_path = series_path 
+        series_load_path = series_path
         if input_path and not series_path:
-             # If specific input path given, we might need a specific series input, but for now defaults work
-             pass
+            # If specific input path given, we might need a specific series input, but for now defaults work
+            pass
 
         # -- 1. LOAD EXISTING DATA --
         # Load Films
         if os.path.exists(load_path):
             try:
-                with open(load_path, 'r', encoding='utf-8') as f:
+                with open(load_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                    existing_items = data.get('items', [])
-                    
+                    existing_items = data.get("items", [])
+
                 logger.info(f"Loaded {len(existing_items)} existing films from {load_path}")
-                
+
                 for film in existing_items:
-                    fid = film['mubi_id']
+                    fid = film["mubi_id"]
                     all_films[fid] = film
-                    if mode == 'shallow':
-                         # Load existing available_countries
-                         if 'available_countries' in film:
-                             film_countries[fid] = film['available_countries']
-                         else:
-                             film_countries[fid] = {}
+                    if mode == "shallow":
+                        # Load existing available_countries
+                        if "available_countries" in film:
+                            film_countries[fid] = film["available_countries"]
+                        else:
+                            film_countries[fid] = {}
                     else:
-                         film_countries[fid] = {}
+                        film_countries[fid] = {}
 
             except Exception as e:
                 logger.error(f"Failed to load existing data from {load_path}: {e}")
         else:
-             logger.info(f"No existing data found at {load_path}. Starting fresh.")
+            logger.info(f"No existing data found at {load_path}. Starting fresh.")
 
         # Load Series
         if os.path.exists(series_load_path):
             try:
-                with open(series_load_path, 'r', encoding='utf-8') as f:
+                with open(series_load_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                    existing_items = data.get('items', [])
-                    
+                    existing_items = data.get("items", [])
+
                 logger.info(f"Loaded {len(existing_items)} existing series from {series_load_path}")
-                
+
                 for item in existing_items:
-                    fid = item['mubi_id']
+                    fid = item["mubi_id"]
                     all_series[fid] = item
-                    if mode == 'shallow':
-                         if 'available_countries' in item:
-                             series_countries[fid] = item['available_countries']
-                         else:
-                             series_countries[fid] = {}
+                    if mode == "shallow":
+                        if "available_countries" in item:
+                            series_countries[fid] = item["available_countries"]
+                        else:
+                            series_countries[fid] = {}
                     else:
-                         series_countries[fid] = {}
+                        series_countries[fid] = {}
 
             except Exception as e:
                 logger.error(f"Failed to load existing series data: {e}")
         else:
-             logger.info("No existing series data found. Starting fresh.")
-
+            logger.info("No existing series data found. Starting fresh.")
 
         # -- 2. DETERMINE TARGETS --
         target_countries = []
-        if mode == 'deep':
+        if mode == "deep":
             logger.info("Starting DEEP sync (Full Calibration)...")
             target_countries = self.COUNTRIES
-        
-        elif mode == 'shallow':
+
+        elif mode == "shallow":
             logger.info("Starting SHALLOW sync (Incremental Update)...")
             if not all_films:
-                 logger.warning("Shallow sync requested but no existing data found. This will effectively be a partial fresh scrape.")
-            
+                logger.warning(
+                    "Shallow sync requested but no existing data found. This will effectively be a partial fresh scrape."
+                )
+
             # Use the existing data (films AND series) to calculate targets
             # Combine values for coverage calculation
             combined_items = list(all_films.values()) + list(all_series.values())
             # Note: calculate_greedy_targets might need adaptation if it relies solely on 'countries' list
-            # We will patch 'countries' list temporarily onto items for the greedy calc if needed, 
+            # We will patch 'countries' list temporarily onto items for the greedy calc if needed,
             # or update calculate_greedy_targets.
             # For this refactor, let's assume keys of available_countries are sufficient.
-            
+
             # Temporary adapter for greedy algo: ensure items have 'countries' list derived from 'available_countries' keys
             for item in combined_items:
-                if 'available_countries' in item and isinstance(item['available_countries'], dict):
-                    item['countries'] = list(item['available_countries'].keys())
+                if "available_countries" in item and isinstance(item["available_countries"], dict):
+                    item["countries"] = list(item["available_countries"].keys())
                 # If old schema 'countries' exists, it stays.
 
             target_countries = self.calculate_greedy_targets(combined_items)
 
         # --- 3. SCRAPING LOOP (PARALLEL) ---
         logger.info(f"Starting scrape for {len(target_countries)} countries: {target_countries}")
-        
+
         scraped_fids_this_run = set()
-        scraped_sids_this_run = set() # Series IDs
+        scraped_sids_this_run = set()  # Series IDs
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.MAX_WORKERS) as executor:
-            future_to_country = {executor.submit(self.fetch_films_for_country, country): country for country in target_countries}
-            
+            future_to_country = {
+                executor.submit(self.fetch_films_for_country, country): country for country in target_countries
+            }
+
             for future in concurrent.futures.as_completed(future_to_country):
                 country = future_to_country[future]
-                
+
                 try:
                     items = future.result()
-                    
+
                     if not items:
-                         logger.warning(f"No items found for {country}")
-                         if mode == 'deep' and country in self.CRITICAL_COUNTRIES:
-                                 errors.append(f"Critical country {country} returned 0 items.")
+                        logger.warning(f"No items found for {country}")
+                        if mode == "deep" and country in self.CRITICAL_COUNTRIES:
+                            errors.append(f"Critical country {country} returned 0 items.")
 
                     # MERGE LOGIC
                     for item in items:
-                        fid = item['id']
-                        
+                        fid = item["id"]
+
                         # Data Mapping - Extended schema
                         new_data = {
                             # Core identifiers
-                            'mubi_id': fid,
-                            
+                            "mubi_id": fid,
                             # Basic metadata
-                            'title': item.get('title'),
-                            'original_title': item.get('original_title'),
-                            'year': item.get('year'),
-                            'duration': item.get('duration'),
-                            'genres': item.get('genres', []),
-                            'directors': [d['name'] for d in item.get('directors', [])],
-                            'short_synopsis': item.get('short_synopsis'),
-                            'default_editorial': item.get('default_editorial'),
-                            'historic_countries': item.get('historic_countries', []),
-                            
+                            "title": item.get("title"),
+                            "original_title": item.get("original_title"),
+                            "year": item.get("year"),
+                            "duration": item.get("duration"),
+                            "genres": item.get("genres", []),
+                            "directors": [d["name"] for d in item.get("directors", [])],
+                            "short_synopsis": item.get("short_synopsis"),
+                            "default_editorial": item.get("default_editorial"),
+                            "historic_countries": item.get("historic_countries", []),
                             # Mubi-specific ratings
-                            'popularity': item.get('popularity'),
-                            'average_rating_out_of_ten': item.get('average_rating_out_of_ten'),
-                            'number_of_ratings': item.get('number_of_ratings'),
-                            'hd': item.get('hd'),
-                            'critic_review_rating': item.get('critic_review_rating'),
-                            
+                            "popularity": item.get("popularity"),
+                            "average_rating_out_of_ten": item.get("average_rating_out_of_ten"),
+                            "number_of_ratings": item.get("number_of_ratings"),
+                            "hd": item.get("hd"),
+                            "critic_review_rating": item.get("critic_review_rating"),
                             # Content rating & warnings
-                            'content_rating': item.get('content_rating'),
+                            "content_rating": item.get("content_rating"),
                             # Scraper-derived MPAA
-                            'mpaa': None,
-                            'content_warnings': item.get('content_warnings', []),
-                            
+                            "mpaa": None,
+                            "content_warnings": item.get("content_warnings", []),
                             # Imagery & artwork
-                            'stills': item.get('stills'),
-                            'still_url': item.get('still_url')['url'] if isinstance(item.get('still_url'), dict) else item.get('still_url'),
-                            'portrait_image': item.get('portrait_image')['url'] if isinstance(item.get('portrait_image'), dict) else item.get('portrait_image'),
-                            'artworks': item.get('artworks', []),
-                            
+                            "stills": item.get("stills"),
+                            "still_url": item.get("still_url")["url"]
+                            if isinstance(item.get("still_url"), dict)
+                            else item.get("still_url"),
+                            "portrait_image": item.get("portrait_image")["url"]
+                            if isinstance(item.get("portrait_image"), dict)
+                            else item.get("portrait_image"),
+                            "artworks": item.get("artworks", []),
                             # Trailers
-                            'trailer_url': item.get('trailer_url'),
-                            'trailer_id': item.get('trailer_id'),
-                            'optimised_trailers': item.get('optimised_trailers'),
-                            
+                            "trailer_url": item.get("trailer_url"),
+                            "trailer_id": item.get("trailer_id"),
+                            "optimised_trailers": item.get("optimised_trailers"),
                             # Availability & playback
-                            'playback_languages': (item.get('consumable') or {}).get('playback_languages'),
-                            
+                            "playback_languages": (item.get("consumable") or {}).get("playback_languages"),
                             # Awards & press
-                            'award': item.get('award'),
-                            'press_quote': item.get('press_quote'),
-                            
+                            "award": item.get("award"),
+                            "press_quote": item.get("press_quote"),
                             # Series/episode info
-                            'episode': item.get('episode'),
-                            'series': item.get('series')
+                            "episode": item.get("episode"),
+                            "series": item.get("series"),
                         }
-                        
+
                         # Prune unnecessary fields from film data
                         self._prune_film_data(new_data)
-                        
+
                         # Enrich genres (LGBTQ+ tagging)
                         self._enrich_genres(new_data)
 
                         # Calculate MPAA Rating
-                        content_rating = new_data.get('content_rating')
+                        content_rating = new_data.get("content_rating")
                         if content_rating:
                             # Use rating_code as primary, fallback to label
-                            rating_code = content_rating.get('rating_code', '')
-                            rating_label = content_rating.get('label', '')
-                            
+                            rating_code = content_rating.get("rating_code", "")
+                            rating_label = content_rating.get("label", "")
+
                             # Check rating_code first, then label
                             key = str(rating_code).upper() if rating_code else str(rating_label).upper()
-                            
+
                             # Look up in the map
                             if key in self.MUBI_TO_MPAA_MAP:
-                                new_data['mpaa'] = {'US': self.MUBI_TO_MPAA_MAP[key]}
+                                new_data["mpaa"] = {"US": self.MUBI_TO_MPAA_MAP[key]}
 
                         # --- DISTINGUISH SERIES VS FILM ---
                         is_series = False
-                        if item.get('episode') is not None or item.get('series') is not None:
+                        if item.get("episode") is not None or item.get("series") is not None:
                             is_series = True
-                        
+
                         if is_series:
                             scraped_sids_this_run.add(fid)
                             target_dict = all_series
                             target_countries_dict = series_countries
-                            
+
                             # Clean up Series Data
                             self._prune_series_data(new_data)
-                            
+
                         else:
                             scraped_fids_this_run.add(fid)
                             target_dict = all_films
@@ -531,45 +551,47 @@ class MubiScraper:
                         else:
                             target_dict[fid] = new_data
                             # CLEANUP: Remove legacy 'countries' if it exists when creating new
-                            target_dict[fid].pop('countries', None)
-                        
+                            target_dict[fid].pop("countries", None)
+
                         # Init country dict
                         if fid not in target_countries_dict:
                             target_countries_dict[fid] = {}
 
                         # Add availability data for this country
                         # We store the 'consumable' object which contains dates and status
-                        consumable = item.get('consumable') or {}
+                        consumable = item.get("consumable") or {}
                         if consumable:
                             # Create a slim copy with only essential fields
                             consumable_copy = consumable.copy()
-                            
+
                             # Remove playback_languages (moved to top level)
-                            consumable_copy.pop('playback_languages', None)
-                            
+                            consumable_copy.pop("playback_languages", None)
+
                             # Prune unused fields to reduce JSON size (~8MB savings)
-                            consumable_copy.pop('offered', None)           # Always catalogue
-                            consumable_copy.pop('film_id', None)           # Already at top level
-                            consumable_copy.pop('film_date_message', None) # Always null
-                            consumable_copy.pop('early_access_film_date_message', None) # Early-access banner text, not used
-                            consumable_copy.pop('exclusive', None)         # Not used
-                            consumable_copy.pop('permit_download', None)   # Not used
-                            
+                            consumable_copy.pop("offered", None)  # Always catalogue
+                            consumable_copy.pop("film_id", None)  # Already at top level
+                            consumable_copy.pop("film_date_message", None)  # Always null
+                            consumable_copy.pop(
+                                "early_access_film_date_message", None
+                            )  # Early-access banner text, not used
+                            consumable_copy.pop("exclusive", None)  # Not used
+                            consumable_copy.pop("permit_download", None)  # Not used
+
                             target_countries_dict[fid][country] = consumable_copy
-                    
+
                     logger.info(f"Finished {country}. Total films: {len(all_films)}, Total series: {len(all_series)}")
-                    
+
                 except Exception as e:
                     import traceback
+
                     logger.error(f"Failed to process {country}: {e}")
                     logger.error(f"Full traceback:\n{traceback.format_exc()}")
                     errors.append(f"{country}: {str(e)}")
 
-
         # --- 4. FINALIZATION & PRUNING ---
-         
+
         # In DEEP mode: Prune removed content
-        if mode == 'deep':
+        if mode == "deep":
             # Prune Films
             initial_count_films = len(all_films)
             for fid in list(all_films.keys()):
@@ -577,7 +599,7 @@ class MubiScraper:
                     del all_films[fid]
                     if fid in film_countries:
                         del film_countries[fid]
-            
+
             removed_count = initial_count_films - len(all_films)
             if removed_count > 0:
                 logger.info(f"DEEP SYNC: Pruned {removed_count} films.")
@@ -589,7 +611,7 @@ class MubiScraper:
                     del all_series[sid]
                     if sid in series_countries:
                         del series_countries[sid]
-            
+
             removed_count_s = initial_count_series - len(all_series)
             if removed_count_s > 0:
                 logger.info(f"DEEP SYNC: Pruned {removed_count_s} series episodes.")
@@ -599,53 +621,53 @@ class MubiScraper:
         for fid, film in all_films.items():
             # Assign aggregated availability data
             avail = film_countries.get(fid, {})
-            
+
             # ZOMBIE FILTER: If no availability in any country, SKIP (Deep Sync Only)
             # In Shallow Sync, we avoid removing items to ensure "append-only" behavior,
             # even if they currently appear to have no availability (zombie state).
-            if mode == 'deep' and not avail:
-                if mode == 'deep': # Only strict prune in deep mode to be safe? 
+            if mode == "deep" and not avail:
+                if mode == "deep":  # Only strict prune in deep mode to be safe?
                     # Actually, we never want zombies in the DB, deep or shallow.
                     # But in shallow mode we might not have updated availability for all countries?
                     # Shallow mode calculates targets based on coverage. If we sync and find it has NO countries now, drop it.
                     pass
-            
+
             if not avail:
-                 # If we have confirmed it has no availability, don't include it.
-                 # The only edge case is if we did a partial sync and missed the country it IS available in?
-                 # But shallow sync uses coverage. If we checked its known countries and found nothing, it's gone.
-                 # If we didn't check its countries, we wouldn't have updated it? 
-                 # Wait, shallow sync only updates. It doesn't delete unless we're in deep mode?
-                 # If shallow sync, 'film_countries' only contains data for synced countries.
-                 # We need to merge with existing data? 
-                 # Unrelated to this specific task, let's stick to the obvious fix for the reported issue which is likely Deep Sync related.
-                 # User's json was likely from a Deep Sync.
-                 pass
+                # If we have confirmed it has no availability, don't include it.
+                # The only edge case is if we did a partial sync and missed the country it IS available in?
+                # But shallow sync uses coverage. If we checked its known countries and found nothing, it's gone.
+                # If we didn't check its countries, we wouldn't have updated it?
+                # Wait, shallow sync only updates. It doesn't delete unless we're in deep mode?
+                # If shallow sync, 'film_countries' only contains data for synced countries.
+                # We need to merge with existing data?
+                # Unrelated to this specific task, let's stick to the obvious fix for the reported issue which is likely Deep Sync related.
+                # User's json was likely from a Deep Sync.
+                pass
 
             # Assign aggregated availability data
             combined_avail = film_countries.get(fid, {})
-            
-            # IMPORTANT: For Zombie filtering, we need to be careful not to drop films in shallow sync 
-            # if we simply didn't scrape their countries. 
+
+            # IMPORTANT: For Zombie filtering, we need to be careful not to drop films in shallow sync
+            # if we simply didn't scrape their countries.
             # But the 'film_countries' dictionary in 'run' is initialized from EXISTING data in step 1.
             # So 'film_countries' contains global availability state.
             # If it's empty, it essentially means the film is gone everywhere.
-            
-            if not combined_avail:
-                 # It's a zombie.
-                 continue
 
-            film['available_countries'] = combined_avail
+            if not combined_avail:
+                # It's a zombie.
+                continue
+
+            film["available_countries"] = combined_avail
             # Remove legacy list if present to ensure schema cleanliness
-            film.pop('countries', None)
+            film.pop("countries", None)
             final_films.append(film)
 
         final_series = []
         for sid, item in all_series.items():
             # Assign aggregated availability data
-            item['available_countries'] = series_countries.get(sid, {})
+            item["available_countries"] = series_countries.get(sid, {})
             # Remove legacy list if present
-            item.pop('countries', None)
+            item.pop("countries", None)
             final_series.append(item)
 
         # PANIC CHECK
@@ -654,45 +676,45 @@ class MubiScraper:
             sys.exit(1)
 
         # VALIDATE (Only in Deep Mode, Only Films for now)
-        if mode == 'deep':
+        if mode == "deep":
             data_errors = self.validate_data(final_films)
             if data_errors:
                 errors.extend(data_errors)
         else:
-             logger.info("Skipping data validation for Shallow Sync (Append-Only mode).")
+            logger.info("Skipping data validation for Shallow Sync (Append-Only mode).")
 
         # SAVE FILMS
         output_films = {
-            'meta': {
-                'generated_at': datetime.utcnow().isoformat() + 'Z',
-                'version': 1,
-                'version_label': '1.0',  # Human-readable version for debugging
-                'total_count': len(final_films),
-                'mode': mode
+            "meta": {
+                "generated_at": datetime.utcnow().isoformat() + "Z",
+                "version": 1,
+                "version_label": "1.0",  # Human-readable version for debugging
+                "total_count": len(final_films),
+                "mode": mode,
             },
-            'items': final_films
+            "items": final_films,
         }
 
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(output_films, f, indent=2, ensure_ascii=False)
-        
+
         logger.info(f"Successfully saved {len(final_films)} films to {output_path}")
 
         # SAVE SERIES
         output_series = {
-            'meta': {
-                'generated_at': datetime.utcnow().isoformat() + 'Z',
-                'version': 1,
-                'version_label': '1.0',  # Human-readable version for debugging
-                'total_count': len(final_series),
-                'mode': mode
+            "meta": {
+                "generated_at": datetime.utcnow().isoformat() + "Z",
+                "version": 1,
+                "version_label": "1.0",  # Human-readable version for debugging
+                "total_count": len(final_series),
+                "mode": mode,
             },
-            'items': final_series
+            "items": final_series,
         }
 
-        with open(series_path, 'w', encoding='utf-8') as f:
+        with open(series_path, "w", encoding="utf-8") as f:
             json.dump(output_series, f, indent=2, ensure_ascii=False)
-        
+
         logger.info(f"Successfully saved {len(final_series)} series episodes to {series_path}")
 
         if errors:
@@ -701,22 +723,30 @@ class MubiScraper:
                 logger.error(f"  - {e}")
             sys.exit(1)
 
+
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(description="Mubi Catalog Scraper")
-    parser.add_argument('--mode', choices=['deep', 'shallow'], default='deep', help="Deep (calibration) or Shallow (fast) sync")
-    parser.add_argument('--output', default='films.json', help="Output films file path")
-    parser.add_argument('--series-output', default='series.json', help="Output series file path")
-    parser.add_argument('--input', default=None, help="Input file path (required for shallow mode)")
-    parser.add_argument('--countries', default=None, help="Comma-separated list of country codes to scrape (e.g., DE,US,GB). Defaults to all.")
-    
+    parser.add_argument(
+        "--mode", choices=["deep", "shallow"], default="deep", help="Deep (calibration) or Shallow (fast) sync"
+    )
+    parser.add_argument("--output", default="films.json", help="Output films file path")
+    parser.add_argument("--series-output", default="series.json", help="Output series file path")
+    parser.add_argument("--input", default=None, help="Input file path (required for shallow mode)")
+    parser.add_argument(
+        "--countries",
+        default=None,
+        help="Comma-separated list of country codes to scrape (e.g., DE,US,GB). Defaults to all.",
+    )
+
     args = parser.parse_args()
-    
+
     scraper = MubiScraper()
-    
+
     # Override COUNTRIES if specified
     if args.countries:
-        scraper.COUNTRIES = [c.strip().upper() for c in args.countries.split(',')]
+        scraper.COUNTRIES = [c.strip().upper() for c in args.countries.split(",")]
         logger.info(f"Limiting scrape to countries: {scraper.COUNTRIES}")
-    
+
     scraper.run(output_path=args.output, series_path=args.series_output, mode=args.mode, input_path=args.input)

--- a/backend/tests/test_weekly_digest.py
+++ b/backend/tests/test_weekly_digest.py
@@ -1,19 +1,12 @@
-import pytest
 import json
-from pathlib import Path
-from datetime import datetime, timedelta, timezone
-from unittest.mock import patch, mock_open
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 # Add backend to path to import script
 sys.path.append(str(Path(__file__).parent.parent))
 
-from generate_weekly_digest import (
-    get_bayesian_score,
-    get_earliest_availability,
-    get_latest_expiration,
-    generate_digest
-)
+from generate_weekly_digest import generate_digest, get_bayesian_score, get_earliest_availability, get_latest_expiration
 
 # Mock Data
 MOCK_FILM_1 = {

--- a/backend/tests/test_weekly_digest.py
+++ b/backend/tests/test_weekly_digest.py
@@ -12,25 +12,19 @@ from generate_weekly_digest import generate_digest, get_bayesian_score, get_earl
 MOCK_FILM_1 = {
     "title": "High Rating Film",
     "ratings": [{"source": "bayesian", "score_over_10": 9.5}],
-    "available_countries": {
-        "US": {"available_at": "2025-01-01T00:00:00Z", "expires_at": "2025-01-31T00:00:00Z"}
-    }
+    "available_countries": {"US": {"available_at": "2025-01-01T00:00:00Z", "expires_at": "2025-01-31T00:00:00Z"}},
 }
 
 MOCK_FILM_2 = {
     "title": "Low Rating Film",
     "ratings": [{"source": "bayesian", "score_over_10": 5.0}],
-    "available_countries": {
-        "UK": {"available_at": "2025-01-05T00:00:00Z"}
-    }
+    "available_countries": {"UK": {"available_at": "2025-01-05T00:00:00Z"}},
 }
 
 MOCK_FILM_OLD = {
     "title": "Old Film",
     "ratings": [{"source": "bayesian", "score_over_10": 8.0}],
-    "available_countries": {
-        "US": {"available_at": "2020-01-01T00:00:00Z"}
-    }
+    "available_countries": {"US": {"available_at": "2020-01-01T00:00:00Z"}},
 }
 
 
@@ -47,12 +41,12 @@ def test_get_earliest_availability():
     assert dt.year == 2025
     assert dt.month == 1
     assert dt.day == 1
-    
+
     # Test multiple countries
     film_multi = {
         "available_countries": {
             "US": {"available_at": "2025-01-10T00:00:00Z"},
-            "UK": {"available_at": "2025-01-01T00:00:00Z"} # Earliest
+            "UK": {"available_at": "2025-01-01T00:00:00Z"},  # Earliest
         }
     }
     dt_multi = get_earliest_availability(film_multi)
@@ -68,7 +62,7 @@ def test_get_latest_expiration():
     assert dt.year == 2025
     assert dt.month == 1
     assert dt.day == 31
-    
+
     assert get_latest_expiration(MOCK_FILM_2) is None
 
 
@@ -76,38 +70,38 @@ def test_generate_digest_filtering(tmp_path):
     """Test that only new movies are included and sorted by rating."""
     # Set "Now" to Jan 7th 2025
     mock_now = datetime(2025, 1, 7, tzinfo=timezone.utc)
-    
+
     # 7 days ago = Jan 1st 2025
     # MOCK_FILM_1 available Jan 1st -> Should include (borderline)
     # MOCK_FILM_2 available Jan 5th -> Should include
     # MOCK_FILM_OLD available 2020 -> Should exclude
-    
+
     input_file = tmp_path / "films.json"
     output_file = tmp_path / "digest.md"
-    
-    data = {"items": [MOCK_FILM_2, MOCK_FILM_OLD, MOCK_FILM_1]} # Mixed order
-    
+
+    data = {"items": [MOCK_FILM_2, MOCK_FILM_OLD, MOCK_FILM_1]}  # Mixed order
+
     with open(input_file, "w") as f:
         json.dump(data, f)
-        
+
     generate_digest(input_file, output_file, now_override=mock_now)
-    
+
     assert output_file.exists()
     content = output_file.read_text()
-    
+
     # Verify filtering
     assert "High Rating Film" in content
     assert "Low Rating Film" in content
     assert "Old Film" not in content
-    
+
     # Verify Sorting (High rated comes first in text)
     pos_high = content.find("High Rating Film")
     pos_low = content.find("Low Rating Film")
     assert pos_high < pos_low
-    
+
     # Verify JSON output
-    json_out = output_file.with_suffix('.json')
+    json_out = output_file.with_suffix(".json")
     assert json_out.exists()
     json_content = json.loads(json_out.read_text())
-    assert len(json_content['newArrivals']) == 2
-    assert json_content['newArrivals'][0]['title'] == "High Rating Film"
+    assert len(json_content["newArrivals"]) == 2
+    assert json_content["newArrivals"][0]["title"] == "High Rating Film"

--- a/backend/tmdb_provider.py
+++ b/backend/tmdb_provider.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
-import requests
 import unicodedata
+from typing import Any, Dict, Optional
 
+import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .external_urls import TMDB_API_URL, IMDB_TITLE_URL_TEMPLATE
-from .metadata_utils import ExternalMetadataResult, TitleNormalizer, RetryStrategy, redact_secrets
+from .external_urls import IMDB_TITLE_URL_TEMPLATE, TMDB_API_URL
+from .metadata_utils import ExternalMetadataResult, RetryStrategy, TitleNormalizer, redact_secrets
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/backend/tmdb_provider.py
+++ b/backend/tmdb_provider.py
@@ -14,36 +14,37 @@ from .metadata_utils import ExternalMetadataResult, RetryStrategy, TitleNormaliz
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
 class TMDBProvider:
     """
     TMDB metadata provider.
-    
+
     Advantages over OMDB:
     - Returns both IMDB ID and TMDB ID
     - Multiple search results for better matching
     - Better support for international titles
     - Free API with higher rate limits
     """
-    
+
     BASE_URL = TMDB_API_URL
-    
+
     def __init__(self, api_key: str, config: Optional[Dict[str, Any]] = None) -> None:
         """Initialize TMDB provider with API key."""
         self.api_key = api_key
         self.config = config or {}
-        
+
         # Initialize Session with Retry logic
         self.session = requests.Session()
         retries = Retry(
             total=self.config.get("max_retries", 3),
             backoff_factor=self.config.get("backoff_factor", 1.0),
             status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET"]
+            allowed_methods=["GET"],
         )
         adapter = HTTPAdapter(max_retries=retries)
-        self.session.mount('https://', adapter)
-        self.session.mount('http://', adapter)
-        
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
         self.title_normalizer = TitleNormalizer()
         # RetryStrategy class unused for session-based approach, but keeping for compatibility if other methods use it
         self.retry_strategy = RetryStrategy(
@@ -52,15 +53,15 @@ class TMDBProvider:
             multiplier=self.config.get("backoff_multiplier", 1.5),
             secrets=(self.api_key,),
         )
-        
+
         # Determine genres dynamically to avoid hardcoding IDs
         self.movie_genres = self._fetch_genres("movie")
         self.tv_genres = self._fetch_genres("tv")
-        
-        
+
         # Import fuzz for matching
         try:
             from thefuzz import fuzz
+
             self.fuzz = fuzz
         except ImportError:
             logger.warning("thefuzz not installed. Falling back to exact matching.")
@@ -69,7 +70,7 @@ class TMDBProvider:
     @property
     def provider_name(self) -> str:
         return "TMDB"
-    
+
     def get_imdb_id(
         self,
         title: str,
@@ -80,23 +81,23 @@ class TMDBProvider:
         mubi_directors: Optional[list] = None,
         mubi_runtime: Optional[int] = None,
         mubi_genres: Optional[list] = None,
-        mubi_id: Optional[int] = None
+        mubi_id: Optional[int] = None,
     ) -> ExternalMetadataResult:
         """
         Fetch IMDB ID and TMDB ID from TMDB using Tri-Vector Verification Protocol.
         """
-        
+
         # Note: We ignore the provided tmdb_id as per new requirements to always verify
-        
+
         mubi_data = {
             "title": title,
             "original_title": original_title,
             "year": year,
             "directors": mubi_directors or [],
             "duration": mubi_runtime,
-            "media_type": media_type
+            "media_type": media_type,
         }
-        
+
         return self._find_match_three_phase(mubi_data, mubi_id)
 
     def _find_match_three_phase(self, mubi_data: dict, mubi_id: Optional[int] = None) -> ExternalMetadataResult:
@@ -106,7 +107,7 @@ class TMDBProvider:
         """
         log_prefix = f"[MubiID:{mubi_id}] " if mubi_id else ""
         media_type = mubi_data.get("media_type", "movie")
-        
+
         # --- Strategy A: Original Title (High Precision) ---
         if mubi_data.get("original_title"):
             logger.debug(f"{log_prefix}Strategy A: Original Title '{mubi_data['original_title']}'")
@@ -114,7 +115,9 @@ class TMDBProvider:
             if candidates:
                 best_match, confidence = self._verify_candidates(mubi_data, candidates, media_type)
                 if best_match and confidence >= 80:
-                    logger.info(f"{log_prefix}MATCH FOUND (Strategy A): TMDB ID {best_match['id']} (Score: {confidence})")
+                    logger.info(
+                        f"{log_prefix}MATCH FOUND (Strategy A): TMDB ID {best_match['id']} (Score: {confidence})"
+                    )
                     return self._build_result(best_match, confidence, mubi_data, media_type)
 
         # --- Strategy B: English Title + Year (High Precision filter) ---
@@ -126,7 +129,9 @@ class TMDBProvider:
             if candidates:
                 best_match, confidence = self._verify_candidates(mubi_data, candidates, media_type)
                 if best_match and confidence >= 80:
-                    logger.info(f"{log_prefix}MATCH FOUND (Strategy B): TMDB ID {best_match['id']} (Score: {confidence})")
+                    logger.info(
+                        f"{log_prefix}MATCH FOUND (Strategy B): TMDB ID {best_match['id']} (Score: {confidence})"
+                    )
                     return self._build_result(best_match, confidence, mubi_data, media_type)
 
         # --- Strategy C: English Title (Wide Net) ---
@@ -136,8 +141,8 @@ class TMDBProvider:
         original_title = mubi_data.get("original_title")
         should_run_wide = True
         if original_title and english_title and original_title.lower() == english_title.lower():
-             should_run_wide = False
-             
+            should_run_wide = False
+
         if should_run_wide and english_title:
             logger.debug(f"{log_prefix}Strategy C: Title '{english_title}' (Wide)")
             # No year filter here
@@ -145,22 +150,25 @@ class TMDBProvider:
             if candidates:
                 best_match, confidence = self._verify_candidates(mubi_data, candidates, media_type)
                 if best_match and confidence >= 80:
-                    logger.info(f"{log_prefix}MATCH FOUND (Strategy C): TMDB ID {best_match['id']} (Score: {confidence})")
+                    logger.info(
+                        f"{log_prefix}MATCH FOUND (Strategy C): TMDB ID {best_match['id']} (Score: {confidence})"
+                    )
                     return self._build_result(best_match, confidence, mubi_data, media_type)
-                    
+
         # --- Strategy F: Split Search (Title : Subtitle) ---
         # Handles "Title: Subtitle" or "Title - Subtitle"
         # Search for the core title part with year
         separators = [":", " - ", " – ", "(", "["]
         candidates_queries = set()
         for t in [mubi_data.get("title"), mubi_data.get("original_title")]:
-            if not t: continue
+            if not t:
+                continue
             for sep in separators:
                 if sep in t:
                     part = t.split(sep)[0].strip()
-                    if len(part) > 2: # Avoid tiny fragments
+                    if len(part) > 2:  # Avoid tiny fragments
                         candidates_queries.add(part)
-        
+
         if candidates_queries:
             logger.debug(f"{log_prefix}Strategy F: Split Title Search {candidates_queries}")
             for q in candidates_queries:
@@ -171,7 +179,9 @@ class TMDBProvider:
                 if results:
                     best_match, confidence = self._verify_candidates(mubi_data, results, media_type)
                     if best_match and confidence >= 80:
-                        logger.info(f"{log_prefix}MATCH FOUND (Strategy F - Split): TMDB ID {best_match['id']} (Score: {confidence})")
+                        logger.info(
+                            f"{log_prefix}MATCH FOUND (Strategy F - Split): TMDB ID {best_match['id']} (Score: {confidence})"
+                        )
                         return self._build_result(best_match, confidence, mubi_data, media_type)
 
         # --- Strategy D: Fallback Neighbor Years ---
@@ -181,101 +191,116 @@ class TMDBProvider:
             # B covered base_year. Try neighbors.
             fallback_years = [base_year + 1, base_year - 1]
             query = mubi_data.get("original_title") or mubi_data.get("title")
-            
+
             fallback_candidates = []
             for fy in fallback_years:
                 results = self._search_api(query, media_type, year=fy)
                 fallback_candidates.extend(results)
-                
+
             if fallback_candidates:
-                 best_match, confidence = self._verify_candidates(mubi_data, fallback_candidates, media_type)
-                 if best_match and confidence >= 80:
-                    logger.info(f"{log_prefix}MATCH FOUND (Strategy D): TMDB ID {best_match['id']} (Score: {confidence})")
+                best_match, confidence = self._verify_candidates(mubi_data, fallback_candidates, media_type)
+                if best_match and confidence >= 80:
+                    logger.info(
+                        f"{log_prefix}MATCH FOUND (Strategy D): TMDB ID {best_match['id']} (Score: {confidence})"
+                    )
                     return self._build_result(best_match, confidence, mubi_data, media_type)
 
         # --- Strategy E: Cross-Media Fallback (TV Check) ---
         # If movie search failed completely, check if it's actually a TV show (Miniseries/TV Movie)
         if media_type == "movie":
-             logger.debug(f"{log_prefix}Strategy E: Cross-Media Fallback (TV Check)")
-             q = mubi_data.get("original_title") or mubi_data.get("title")
-             # Try simple search without year first to allow flexibility (miniseries often span years)
-             tv_results = self._search_api(q, media_type="tv")
-             
-             if tv_results:
-                 best_tv, tv_score = self._verify_candidates(mubi_data, tv_results, tmdb_media_type="tv")
-                 if best_tv and tv_score >= 80:
-                     logger.info(f"{log_prefix}MATCH FOUND (Strategy E - TV Fallback): TMDB ID {best_tv['id']} (Score: {tv_score})")
-                     return self._build_result(best_tv, tv_score, mubi_data, media_type="tv")
+            logger.debug(f"{log_prefix}Strategy E: Cross-Media Fallback (TV Check)")
+            q = mubi_data.get("original_title") or mubi_data.get("title")
+            # Try simple search without year first to allow flexibility (miniseries often span years)
+            tv_results = self._search_api(q, media_type="tv")
+
+            if tv_results:
+                best_tv, tv_score = self._verify_candidates(mubi_data, tv_results, tmdb_media_type="tv")
+                if best_tv and tv_score >= 80:
+                    logger.info(
+                        f"{log_prefix}MATCH FOUND (Strategy E - TV Fallback): TMDB ID {best_tv['id']} (Score: {tv_score})"
+                    )
+                    return self._build_result(best_tv, tv_score, mubi_data, media_type="tv")
 
         logger.info(f"{log_prefix}No match met threshold after all strategies.")
         return ExternalMetadataResult(
-            success=False,
-            source_provider=self.provider_name,
-            error_message="No match met confidence threshold"
+            success=False, source_provider=self.provider_name, error_message="No match met confidence threshold"
         )
 
-    def _build_result(self, best_match: dict, confidence: int, mubi_data: dict, media_type: str) -> ExternalMetadataResult:
+    def _build_result(
+        self, best_match: dict, confidence: int, mubi_data: dict, media_type: str
+    ) -> ExternalMetadataResult:
         """Helper to construct ExternalMetadataResult."""
         external_ids = best_match.get("external_ids", {})
         tmdb_crew = best_match.get("credits", {}).get("crew", [])
         tmdb_directors = [p["name"] for p in tmdb_crew if p.get("job") == "Director"]
-        
+
         return ExternalMetadataResult(
             success=True,
             tmdb_id=str(best_match["id"]),
             imdb_id=external_ids.get("imdb_id"),
-            imdb_url=IMDB_TITLE_URL_TEMPLATE.format(imdb_id=external_ids["imdb_id"]) if external_ids.get("imdb_id") else None,
+            imdb_url=IMDB_TITLE_URL_TEMPLATE.format(imdb_id=external_ids["imdb_id"])
+            if external_ids.get("imdb_id")
+            else None,
             source_provider=self.provider_name,
             vote_average=best_match.get("vote_average"),
             vote_count=best_match.get("vote_count"),
             # Verification Data
             matched_title=best_match.get("title") or best_match.get("name"),
             matched_original_title=best_match.get("original_title") or best_match.get("original_name"),
-            matched_year=self._extract_year(best_match.get("release_date") if media_type == "movie" else best_match.get("first_air_date")),
+            matched_year=self._extract_year(
+                best_match.get("release_date") if media_type == "movie" else best_match.get("first_air_date")
+            ),
             matched_directors=tmdb_directors,
             match_score=confidence,
             match_details={
-                "year_delta": abs(int(best_match.get("release_date", "0000").split("-")[0]) - mubi_data["year"]) if mubi_data.get("year") and best_match.get("release_date") else None,
-                "strategy": "sequential"
-            }
+                "year_delta": abs(int(best_match.get("release_date", "0000").split("-")[0]) - mubi_data["year"])
+                if mubi_data.get("year") and best_match.get("release_date")
+                else None,
+                "strategy": "sequential",
+            },
         )
 
     def _verify_candidates(self, mubi_data: dict, candidates: list, tmdb_media_type: str) -> tuple[Optional[dict], int]:
         """Helper to run deep verification on a list of candidates."""
         best_match = None
         highest_confidence = 0
-        
+
         target_year = mubi_data.get("year")
-        
+
         for item in candidates:
             # Phase II: Temporal Pre-Filtering
             if target_year:
-                cand_year = self._extract_year(item.get("release_date") if tmdb_media_type == "movie" else item.get("first_air_date"))
+                cand_year = self._extract_year(
+                    item.get("release_date") if tmdb_media_type == "movie" else item.get("first_air_date")
+                )
                 if cand_year:
                     year_delta = abs(cand_year - target_year)
                     # Allow up to 3 years delta, UNLESS title is an exact match (handle Remasters/Re-releases)
-                    is_exact_title = (item.get("title", "").lower().strip() == mubi_data.get("title", "").lower().strip())
-                    
-                    if year_delta > 3 and not is_exact_title:
-                         continue
+                    is_exact_title = item.get("title", "").lower().strip() == mubi_data.get("title", "").lower().strip()
 
-             # Fetch full details
+                    if year_delta > 3 and not is_exact_title:
+                        continue
+
+            # Fetch full details
             details = self._get_details_with_credits(item["id"], media_type=tmdb_media_type)
-            if not details: continue
-            
-            tmdb_year = self._extract_year(item.get("release_date") if tmdb_media_type == "movie" else item.get("first_air_date"))
+            if not details:
+                continue
+
+            tmdb_year = self._extract_year(
+                item.get("release_date") if tmdb_media_type == "movie" else item.get("first_air_date")
+            )
             confidence_score = self._calculate_final_score(mubi_data, details, tmdb_year)
-            
+
             if confidence_score > highest_confidence:
                 highest_confidence = confidence_score
                 best_match = details
-                
+
         return best_match, highest_confidence
 
     def _calculate_final_score(self, mubi_data: dict, tmdb_details: dict, tmdb_year: Optional[int]) -> int:
         """Calculate the confidence score based on the Tri-Vector weights."""
         score = 0
-        
+
         if not self.fuzz:
             logger.warning("Fuzzy matching disabled (thefuzz missing). Cannot verify director/title.")
             if mubi_data.get("year") and tmdb_year and mubi_data["year"] == tmdb_year:
@@ -286,80 +311,82 @@ class TMDBProvider:
         mubi_directors = [d.lower() for d in mubi_data.get("directors", [])]
         tmdb_crew = tmdb_details.get("credits", {}).get("crew", [])
         tmdb_directors = [p["name"].lower() for p in tmdb_crew if p.get("job") == "Director"]
-        
+
         # 2. Title Match (+30)
         mubi_title = mubi_data.get("title", "")
         mubi_ot = mubi_data.get("original_title", "")
-        
+
         tmdb_title = tmdb_details.get("title") or tmdb_details.get("name") or ""
         tmdb_ot = tmdb_details.get("original_title") or tmdb_details.get("original_name") or ""
-        
+
         tmdb_titles = {tmdb_title, tmdb_ot}
-        
+
         alts_data = tmdb_details.get("alternative_titles", {})
         alternatives = alts_data.get("titles", []) + alts_data.get("results", [])
-        
+
         for alt in alternatives:
             if alt.get("title"):
                 tmdb_titles.add(alt["title"])
-        
+
         max_title_score = 0
-        
+
         mubi_title_norm = self._normalize_string(mubi_title)
         mubi_ot_norm = self._normalize_string(mubi_ot)
-        
+
         for t_tmdb in tmdb_titles:
             s1 = self.fuzz.token_set_ratio(mubi_title, t_tmdb)
             s2 = self.fuzz.token_set_ratio(mubi_ot, t_tmdb)
-            
+
             t_tmdb_norm = self._normalize_string(t_tmdb)
             s3 = self.fuzz.token_set_ratio(mubi_title_norm, t_tmdb_norm)
             s4 = self.fuzz.token_set_ratio(mubi_ot_norm, t_tmdb_norm)
-            
+
             max_title_score = max(max_title_score, s1, s2, s3, s4)
-        
+
         # Director Matching
         director_match = False
         if mubi_directors and tmdb_directors:
             mubi_directors_norm = [self._normalize_string(d) for d in mubi_data.get("directors", [])]
             tmdb_directors_norm = [self._normalize_string(p["name"]) for p in tmdb_crew if p.get("job") == "Director"]
-            
+
             for md in mubi_directors_norm:
                 for td in tmdb_directors_norm:
                     if self.fuzz.WRatio(md, td) >= 85:
                         director_match = True
                         break
-                if director_match: break
-            
+                if director_match:
+                    break
+
             if not director_match:
                 for md in mubi_directors_norm:
                     parts = md.split()
                     if len(parts) > 1:
                         md_reversed = f"{parts[-1]} {' '.join(parts[:-1])}"
                         for td in tmdb_directors_norm:
-                             if self.fuzz.WRatio(md_reversed, td) >= 85:
+                            if self.fuzz.WRatio(md_reversed, td) >= 85:
                                 director_match = True
                                 break
-                             
-                             stopwords = {"brothers", "bros", "sisters", "the", "and", "&"}
-                             md_tokens = {t for t in set(md.split()) if t not in stopwords}
-                             td_tokens = {t for t in set(td.split()) if t not in stopwords}
-                             
-                             if not md_tokens or not td_tokens:
-                                 md_tokens = set(md.split())
-                                 td_tokens = set(td.split())
-                             
-                             common = len(md_tokens & td_tokens)
-                             total = min(len(md_tokens), len(td_tokens))
-                             threshold = 0.5 if max_title_score > 80 else 0.51
-                             matched_tokens = md_tokens & td_tokens
-                             valid_overlap = any(len(t) > 3 for t in matched_tokens)
-                             
-                             if total > 0 and (common / total) >= threshold and valid_overlap:
-                                 director_match = True
-                                 break
-                                      
-                    if director_match: break
+
+                            stopwords = {"brothers", "bros", "sisters", "the", "and", "&"}
+                            md_tokens = {t for t in set(md.split()) if t not in stopwords}
+                            td_tokens = {t for t in set(td.split()) if t not in stopwords}
+
+                            if not md_tokens or not td_tokens:
+                                md_tokens = set(md.split())
+                                td_tokens = set(td.split())
+
+                            common = len(md_tokens & td_tokens)
+                            total = min(len(md_tokens), len(td_tokens))
+                            threshold = 0.5 if max_title_score > 80 else 0.51
+                            matched_tokens = md_tokens & td_tokens
+                            valid_overlap = any(len(t) > 3 for t in matched_tokens)
+
+                            if total > 0 and (common / total) >= threshold and valid_overlap:
+                                director_match = True
+                                break
+
+                    if director_match:
+                        break
 
             if not director_match and max_title_score > 90:
                 for md in mubi_directors_norm:
@@ -369,16 +396,17 @@ class TMDBProvider:
                         if md_last and td_last and md_last == td_last and len(md_last) > 2:
                             director_match = True
                             break
-                    if director_match: break
+                    if director_match:
+                        break
 
         if director_match:
             score += 50
         elif mubi_directors and tmdb_directors:
             score -= 20
-            
+
         if max_title_score > 90:
             score += 30
-            
+
         # 3. Year Exact Match (+10)
         if mubi_data.get("year") and tmdb_year:
             year_delta = abs(mubi_data["year"] - tmdb_year)
@@ -386,7 +414,7 @@ class TMDBProvider:
                 score += 10
             elif year_delta == 1:
                 score += 5
-        
+
         # 4. Runtime Match (+10)
         mubi_dur = mubi_data.get("duration")
         tmdb_dur = tmdb_details.get("runtime")
@@ -396,31 +424,31 @@ class TMDBProvider:
                 score += 10
             elif diff > 40:
                 if director_match and max_title_score > 90:
-                    score -= 10 
+                    score -= 10
                 else:
                     score -= 30
-                
+
         return score
 
     def _search_api(self, query: str, media_type: str, year: Optional[int] = None, include_adult: bool = True) -> list:
         """Internal wrapper for search API to handle year filtering."""
         # Sanitize query: TMDB search fails with underscores (e.g. "Hoax_canular")
         sanitized_query = query.replace("_", " ")
-        
+
         endpoint = "search/movie" if media_type == "movie" else "search/tv"
         params = {
             "api_key": self.api_key,
             "query": sanitized_query,
             "include_adult": str(include_adult).lower(),
             "language": "en-US",
-            "page": 1
+            "page": 1,
         }
         if year:
-             params["year"] = year # strict primary release year filter for movies
-             # For TV it is first_air_date_year
-             if media_type != "movie":
-                 del params["year"]
-                 params["first_air_date_year"] = year
+            params["year"] = year  # strict primary release year filter for movies
+            # For TV it is first_air_date_year
+            if media_type != "movie":
+                del params["year"]
+                params["first_air_date_year"] = year
 
         url = f"{self.BASE_URL}/{endpoint}"
         try:
@@ -434,10 +462,7 @@ class TMDBProvider:
     def _get_details_with_credits(self, tmdb_id: int, media_type: str) -> dict:
         """Fetch details with append_to_response=credits,external_ids."""
         url = f"{self.BASE_URL}/{media_type}/{tmdb_id}"
-        params = {
-            "api_key": self.api_key,
-            "append_to_response": "credits,external_ids,alternative_titles"
-        }
+        params = {"api_key": self.api_key, "append_to_response": "credits,external_ids,alternative_titles"}
         try:
             response = self.session.get(url, params=params, timeout=10)
             if response.ok:
@@ -447,7 +472,8 @@ class TMDBProvider:
         return {}
 
     def _extract_year(self, date_str: Optional[str]) -> Optional[int]:
-        if not date_str: return None
+        if not date_str:
+            return None
         try:
             return int(date_str.split("-")[0])
         except (ValueError, IndexError):
@@ -456,15 +482,11 @@ class TMDBProvider:
     def test_connection(self) -> bool:
         """Test whether the provider is reachable."""
         try:
-            response = requests.get(
-                f"{self.BASE_URL}/configuration",
-                params={"api_key": self.api_key},
-                timeout=10
-            )
+            response = requests.get(f"{self.BASE_URL}/configuration", params={"api_key": self.api_key}, timeout=10)
             return response.status_code == 200
         except Exception:
             return False
-            
+
     def _fetch_genres(self, media_type: str) -> Dict[int, str]:
         """
         Fetch genre mapping from TMDB API to avoid hardcoded IDs.
@@ -485,6 +507,6 @@ class TMDBProvider:
         """Normalize string to ASCII, removing accents and lowering case. Replaces hyphens with spaces."""
         if not s:
             return ""
-        s = unicodedata.normalize('NFD', s)
+        s = unicodedata.normalize("NFD", s)
         # Keep alphanumeric, but replace hyphen with space to split tokens
-        return "".join(c if c.isalnum() else ' ' for c in s if unicodedata.category(c) != 'Mn').lower()
+        return "".join(c if c.isalnum() else " " for c in s if unicodedata.category(c) != "Mn").lower()

--- a/backend/validate_schema.py
+++ b/backend/validate_schema.py
@@ -27,8 +27,8 @@ def load_schema(version: int) -> dict:
     schema_path = Path(__file__).parent / "schemas" / f"v{version}_schema.json"
     if not schema_path.exists():
         raise FileNotFoundError(f"Schema file not found: {schema_path}")
-    
-    with open(schema_path, 'r') as f:
+
+    with open(schema_path, "r") as f:
         return json.load(f)
 
 
@@ -39,52 +39,48 @@ def validate_film(film: dict, schema: dict) -> list:
     """
     errors = []
     validator = jsonschema.Draft7Validator(schema)
-    
+
     for error in validator.iter_errors(film):
         path = " -> ".join(str(p) for p in error.path) if error.path else "(root)"
         errors.append(f"[{path}] {error.message}")
-    
+
     return errors
 
 
 def validate_database(data: dict, schema: dict, strict: bool = False) -> tuple:
     """
     Validate the entire database file.
-    
+
     Args:
         data: The parsed JSON data (with meta and items)
         schema: The JSON schema for individual films
         strict: If True, fail on first error. If False, collect all errors.
-    
+
     Returns:
         Tuple of (is_valid: bool, errors: list, stats: dict)
     """
     all_errors = []
-    stats = {
-        "total_items": 0,
-        "valid_items": 0,
-        "invalid_items": 0
-    }
-    
+    stats = {"total_items": 0, "valid_items": 0, "invalid_items": 0}
+
     items = data.get("items", [])
     stats["total_items"] = len(items)
-    
+
     for idx, film in enumerate(items):
         errors = validate_film(film, schema)
-        
+
         if errors:
             stats["invalid_items"] += 1
             film_id = film.get("mubi_id", f"index_{idx}")
             film_title = film.get("title", "Unknown")
-            
+
             for error in errors:
                 all_errors.append(f"Film {film_id} ({film_title}): {error}")
-            
+
             if strict:
                 break
         else:
             stats["valid_items"] += 1
-    
+
     is_valid = len(all_errors) == 0
     return is_valid, all_errors, stats
 
@@ -95,64 +91,64 @@ def main():
     parser.add_argument("--version", type=int, default=1, help="Schema version to validate against")
     parser.add_argument("--strict", action="store_true", help="Fail on first error")
     parser.add_argument("--max-errors", type=int, default=20, help="Maximum errors to display")
-    
+
     args = parser.parse_args()
-    
+
     # Load the JSON file
     if not os.path.exists(args.path):
         print(f"ERROR: File not found: {args.path}")
         sys.exit(1)
-    
+
     print(f"Loading {args.path}...")
-    with open(args.path, 'r') as f:
+    with open(args.path, "r") as f:
         data = json.load(f)
-    
+
     # Check meta version
     meta = data.get("meta", {})
     file_version = meta.get("version", 1)
     version_label = meta.get("version_label", f"{file_version}.0")
-    
+
     print(f"File version: {file_version} (label: {version_label})")
     print(f"Validating against schema v{args.version}...")
-    
+
     if file_version != args.version:
         print(f"WARNING: File version ({file_version}) differs from requested schema version ({args.version})")
-    
+
     # Load schema and validate
     try:
         schema = load_schema(args.version)
     except FileNotFoundError as e:
         print(f"ERROR: {e}")
         sys.exit(1)
-    
+
     is_valid, errors, stats = validate_database(data, schema, strict=args.strict)
-    
+
     # Print results
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("VALIDATION RESULTS")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(f"Total items: {stats['total_items']}")
     print(f"Valid items: {stats['valid_items']}")
     print(f"Invalid items: {stats['invalid_items']}")
-    
+
     if errors:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"ERRORS (showing first {min(len(errors), args.max_errors)}):")
-        print(f"{'='*60}")
-        for error in errors[:args.max_errors]:
+        print(f"{'=' * 60}")
+        for error in errors[: args.max_errors]:
             print(f"  ❌ {error}")
-        
+
         if len(errors) > args.max_errors:
             print(f"\n  ... and {len(errors) - args.max_errors} more errors")
-        
-        print(f"\n{'='*60}")
+
+        print(f"\n{'=' * 60}")
         print("VALIDATION FAILED")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         sys.exit(1)
     else:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("✅ VALIDATION PASSED")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         sys.exit(0)
 
 

--- a/backend/validate_schema.py
+++ b/backend/validate_schema.py
@@ -11,8 +11,8 @@ Used in CI workflows to ensure schema compliance before deployment.
 
 import argparse
 import json
-import sys
 import os
+import sys
 from pathlib import Path
 
 try:
@@ -129,7 +129,7 @@ def main():
     
     # Print results
     print(f"\n{'='*60}")
-    print(f"VALIDATION RESULTS")
+    print("VALIDATION RESULTS")
     print(f"{'='*60}")
     print(f"Total items: {stats['total_items']}")
     print(f"Valid items: {stats['valid_items']}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+# Ruff configuration. See issue #49: adopt ruff, fix F-class findings, gate lint in CI.
+[tool.ruff]
+line-length = 120
+target-version = "py38"  # plugin runs on Kodi's Python 3.8; backend on 3.11 is a superset.
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+# E501 (line-too-long) is delegated to `ruff format`, which owns line length for code
+# and deliberately will not split strings, comments, or URLs. Enforcing E501 on those
+# unsplittable lines is noise, so we let the formatter keep code within line-length.
+ignore = ["E501"]

--- a/repo/plugin_video_mubi/addon.py
+++ b/repo/plugin_video_mubi/addon.py
@@ -6,20 +6,24 @@
 
 
 
-from resources.lib.session_manager import SessionManager
-from resources.lib.navigation_handler import NavigationHandler
-from resources.lib.mubi import Mubi
-import xbmcaddon
-import xbmcplugin
-from urllib.parse import parse_qsl
 import sys
-import xbmc
 from urllib.parse import parse_qsl, unquote_plus
+
+import xbmc
+import xbmcaddon
 import xbmcgui
+import xbmcplugin
 from resources.lib.migrations import (
-    add_mubi_source, is_first_run, mark_first_run, migrate_genre_settings,
-    migrate_to_fast_sync
+    add_mubi_source,
+    is_first_run,
+    mark_first_run,
+    migrate_genre_settings,
+    migrate_to_fast_sync,
 )
+from resources.lib.mubi import Mubi
+from resources.lib.navigation_handler import NavigationHandler
+from resources.lib.session_manager import SessionManager
+
 
 def main(argv):
     plugin = xbmcaddon.Addon()

--- a/repo/plugin_video_mubi/addon.py
+++ b/repo/plugin_video_mubi/addon.py
@@ -1,9 +1,8 @@
 # Kodi plugin that integrates with the Mubi API to display films and categories within the Kodi interface.
-# It allows users to browse Mubi films, sync film metadata locally, 
+# It allows users to browse Mubi films, sync film metadata locally,
 # and play films or trailers externally using a web browser.
-# The plugin handles navigation, builds the user interface for displaying categories and films, 
+# The plugin handles navigation, builds the user interface for displaying categories and films,
 # and manages interactions with the Mubi API.
-
 
 
 import sys
@@ -53,8 +52,6 @@ def main(argv):
     # the user can still opt back out afterwards.
     migrate_to_fast_sync(plugin)
 
-
-
     # Fetch and set client country if it's not already set
     if not session.client_country:
         client_country = mubi.get_cli_country()
@@ -64,7 +61,6 @@ def main(argv):
     if not session.client_language:
         client_language = mubi.get_cli_language()  # Assuming you have a similar method for language
         session.set_client_language(client_language)
-
 
     navigation = NavigationHandler(handle, base_url, mubi, session)
 
@@ -98,7 +94,7 @@ def main(argv):
     elif action == "play_ext":
         xbmc.log(f"Calling play_ext with handle: {handle}", xbmc.LOGDEBUG)
         try:
-            navigation.play_video_ext(params['web_url'])
+            navigation.play_video_ext(params["web_url"])
             xbmcplugin.endOfDirectory(handle, succeeded=True)
         except Exception as e:
             xbmc.log(f"Error in play_ext action: {e}", xbmc.LOGERROR)
@@ -106,7 +102,7 @@ def main(argv):
     elif action == "play_trailer":
         xbmc.log(f"Calling play_trailer with handle: {handle}", xbmc.LOGDEBUG)
         try:
-            navigation.play_trailer(params['url'])
+            navigation.play_trailer(params["url"])
             xbmcplugin.endOfDirectory(handle, succeeded=True)
         except Exception as e:
             xbmc.log(f"Error in play_trailer action: {e}", xbmc.LOGERROR)
@@ -120,20 +116,20 @@ def main(argv):
                 navigation.sync_films(countries=[client_country.upper()])
             else:
                 xbmcgui.Dialog().notification(
-                    "MUBI", "No country configured. Please set your country in Settings.",
-                    xbmcgui.NOTIFICATION_ERROR
+                    "MUBI", "No country configured. Please set your country in Settings.", xbmcgui.NOTIFICATION_ERROR
                 )
             # Sync is a one-shot action, not a directory listing.
             # Refresh the container to return to the main menu after sync completes.
-            xbmc.executebuiltin('Container.Refresh')
+            xbmc.executebuiltin("Container.Refresh")
         except Exception as e:
             xbmc.log(f"Error in sync_locally action: {e}", xbmc.LOGERROR)
-            xbmc.executebuiltin('Container.Refresh')
+            xbmc.executebuiltin("Container.Refresh")
     elif action == "sync_worldwide":
         xbmc.log(f"Calling sync_films (worldwide) with handle: {handle}", xbmc.LOGDEBUG)
         try:
             # Use coverage optimizer to find minimum countries for 100% coverage
             from resources.lib.coverage_optimizer import get_optimal_countries
+
             client_country = plugin.getSetting("client_country") or "CH"
 
             optimal_countries = get_optimal_countries(client_country)
@@ -142,7 +138,7 @@ def main(argv):
                 xbmc.log(
                     f"Worldwide sync: Using {len(optimal_countries)} optimized countries "
                     f"(starting with {client_country.upper()})",
-                    xbmc.LOGINFO
+                    xbmc.LOGINFO,
                 )
                 dialog_title = f"Syncing MUBI Worldwide ({len(optimal_countries)} countries)"
                 navigation.sync_films(countries=optimal_countries, dialog_title=dialog_title)
@@ -150,27 +146,28 @@ def main(argv):
                 # Fallback: if no catalogue available, use all countries
                 xbmc.log("No country catalogue found, falling back to all countries", xbmc.LOGWARNING)
                 from resources.lib.countries import COUNTRIES
+
                 all_countries = [c.upper() for c in COUNTRIES.keys()]
                 navigation.sync_films(countries=all_countries, dialog_title="Syncing MUBI Worldwide")
 
             # Refresh the container to return to the main menu after sync completes.
-            xbmc.executebuiltin('Container.Refresh')
+            xbmc.executebuiltin("Container.Refresh")
         except Exception as e:
             xbmc.log(f"Error in sync_worldwide action: {e}", xbmc.LOGERROR)
-            xbmc.executebuiltin('Container.Refresh')
+            xbmc.executebuiltin("Container.Refresh")
     elif action == "sync_github":
         xbmc.log(f"Calling sync_from_github with handle: {handle}", xbmc.LOGDEBUG)
         try:
             country = params.get("country")
             navigation.sync_from_github(country=country)
-            xbmc.executebuiltin('Container.Refresh')
+            xbmc.executebuiltin("Container.Refresh")
         except Exception as e:
             xbmc.log(f"Error in sync_github action: {e}", xbmc.LOGERROR)
-            xbmc.executebuiltin('Container.Refresh')
+            xbmc.executebuiltin("Container.Refresh")
     elif action == "play_mubi_video":
         xbmc.log(f"Calling play_mubi_video with handle: {handle}", xbmc.LOGDEBUG)
-        film_id = params.get('film_id')
-        web_url = params.get('web_url')
+        film_id = params.get("film_id")
+        web_url = params.get("web_url")
         if web_url:
             web_url = unquote_plus(web_url)
         try:
@@ -184,6 +181,6 @@ def main(argv):
     else:
         navigation.main_navigation()
 
+
 if __name__ == "__main__":
     main(sys.argv)
-

--- a/repo/plugin_video_mubi/resources/lib/availability.py
+++ b/repo/plugin_video_mubi/resources/lib/availability.py
@@ -10,6 +10,7 @@ never as strings: lexical comparison of ISO-8601 strings only happens to work
 when every value shares an identical format and offset suffix, and silently
 mis-orders otherwise (e.g. ``...T07:53:51+02:00`` vs ``...T06:53:51Z``).
 """
+
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -57,8 +58,8 @@ def is_country_available(details: dict, now: Optional[datetime] = None) -> bool:
     if now is None:
         now = datetime.now(timezone.utc)
 
-    available_at = details.get('available_at')
-    ends_at = details.get('expires_at') or details.get('availability_ends_at')
+    available_at = details.get("available_at")
+    ends_at = details.get("expires_at") or details.get("availability_ends_at")
 
     if available_at or ends_at:
         try:
@@ -72,10 +73,9 @@ def is_country_available(details: dict, now: Optional[datetime] = None) -> bool:
             # not enough to be "available" — fall through to the status check.
         except (ValueError, OverflowError, TypeError) as e:
             xbmc.log(
-                f"Error parsing availability dates ({e}); "
-                f"falling back to status check",
+                f"Error parsing availability dates ({e}); falling back to status check",
                 xbmc.LOGWARNING,
             )
             # Fall through to the legacy status check below.
 
-    return details.get('availability') == 'live'
+    return details.get("availability") == "live"

--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -52,9 +52,7 @@ IMDB_TITLE_URL_TEMPLATE = "https://www.imdb.com/title/{imdb_id}/"
 # --- Plugin's own hosted data -------------------------------------------
 
 # Pre-computed, compressed catalog published on this repo's `database` branch.
-CATALOG_FILMS_URL = (
-    "https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz"
-)
+CATALOG_FILMS_URL = "https://github.com/kubi2021/plugin.video.mubi/raw/database/v1/films.json.gz"
 
 
 # --- Healthcheck --------------------------------------------------------

--- a/repo/plugin_video_mubi/resources/lib/coverage_optimizer.py
+++ b/repo/plugin_video_mubi/resources/lib/coverage_optimizer.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Optional
 try:
     import xbmc
     import xbmcaddon
+
     RUNNING_IN_KODI = True
 except ImportError:
     RUNNING_IN_KODI = False
@@ -24,12 +25,12 @@ except ImportError:
 def _get_catalogue_path() -> str:
     """Get the path to the country catalogue JSON file."""
     if RUNNING_IN_KODI:
-        addon_path = xbmcaddon.Addon().getAddonInfo('path')
-        return os.path.join(addon_path, 'resources', 'data', 'country_catalogue.json')
+        addon_path = xbmcaddon.Addon().getAddonInfo("path")
+        return os.path.join(addon_path, "resources", "data", "country_catalogue.json")
     else:
         # For testing or standalone use
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        return os.path.join(current_dir, '..', 'data', 'country_catalogue.json')
+        return os.path.join(current_dir, "..", "data", "country_catalogue.json")
 
 
 def load_country_catalogue() -> Optional[Dict]:
@@ -48,10 +49,10 @@ def load_country_catalogue() -> Optional[Dict]:
         return None
 
     try:
-        with open(catalogue_path, 'r', encoding='utf-8') as f:
+        with open(catalogue_path, "r", encoding="utf-8") as f:
             data = json.load(f)
 
-        if 'films' not in data:
+        if "films" not in data:
             if RUNNING_IN_KODI:
                 xbmc.log("Invalid country catalogue format: missing 'films' key", xbmc.LOGERROR)
             return None
@@ -86,7 +87,7 @@ def get_optimal_countries(user_country: str) -> List[str]:
     country_films = defaultdict(set)
     all_films = set()
 
-    for film_id, countries in catalogue['films'].items():
+    for film_id, countries in catalogue["films"].items():
         film_id_int = int(film_id)
         all_films.add(film_id_int)
         for country in countries:
@@ -115,13 +116,14 @@ def get_optimal_countries(user_country: str) -> List[str]:
     # Greedily select countries that cover the most uncovered films
     # Tiebreaker: prefer countries with lower VPN tier (better infrastructure)
     while covered != all_films and remaining:
+
         def country_score(c):
             new_films_count = len(remaining[c] - covered)
             # VPN tier: 1=best, 4=worst. Use negative for descending sort on coverage
-            vpn_tier = COUNTRIES.get(c, {}).get('vpn_tier', 4)
+            vpn_tier = COUNTRIES.get(c, {}).get("vpn_tier", 4)
             # Return tuple: (new_films DESC, vpn_tier ASC)
             return (-new_films_count, vpn_tier)
-        
+
         best = min(remaining.keys(), key=country_score)
         new_films = remaining[best] - covered
 
@@ -136,7 +138,7 @@ def get_optimal_countries(user_country: str) -> List[str]:
         xbmc.log(
             f"Coverage optimizer: {len(selected)} countries needed for 100% coverage "
             f"(starting with {user_country.upper()})",
-            xbmc.LOGINFO
+            xbmc.LOGINFO,
         )
 
     return selected
@@ -160,7 +162,7 @@ def get_coverage_stats(user_country: str) -> dict:
     country_films = defaultdict(set)
     all_films = set()
 
-    for film_id, countries in catalogue['films'].items():
+    for film_id, countries in catalogue["films"].items():
         film_id_int = int(film_id)
         all_films.add(film_id_int)
         for country in countries:
@@ -169,10 +171,9 @@ def get_coverage_stats(user_country: str) -> dict:
     optimal = get_optimal_countries(user_country)
 
     return {
-        'total_films': len(all_films),
-        'total_countries_available': len(country_films),
-        'optimal_countries': optimal,
-        'optimal_country_count': len(optimal),
-        'user_country_films': len(country_films.get(user_country_lower, set())),
+        "total_films": len(all_films),
+        "total_countries_available": len(country_films),
+        "optimal_countries": optimal,
+        "optimal_country_count": len(optimal),
+        "user_country_films": len(country_films.get(user_country_lower, set())),
     }
-

--- a/repo/plugin_video_mubi/resources/lib/data_source.py
+++ b/repo/plugin_video_mubi/resources/lib/data_source.py
@@ -11,22 +11,25 @@ except ImportError:  # imported as a top-level module (e.g. some test harnesses)
     from availability import is_country_available
     from constants import CATALOG_FILMS_URL
 
+
 class FilmDataSource:
     """
     Interface for a film data source.
     Must return a list of raw film data dictionaries.
     """
+
     def get_films(self, *args, **kwargs) -> List[Dict[str, Any]]:
         raise NotImplementedError
+
 
 class MubiApiDataSource(FilmDataSource):
     """
     Fetches film data directly from the Mubi API.
     Replicates the logic previously in mubi.py's get_all_films.
     """
-    
+
     # Countries to sync catalogues from (ISO 3166-1 alpha-2 codes)
-    SYNC_COUNTRIES = ['CH', 'DE', 'US', 'GB', 'FR', 'JP']
+    SYNC_COUNTRIES = ["CH", "DE", "US", "GB", "FR", "JP"]
 
     def __init__(self, mubi_client):
         """
@@ -35,14 +38,11 @@ class MubiApiDataSource(FilmDataSource):
         self.mubi = mubi_client
 
     def get_films(
-        self, 
-        playable_only: bool = True, 
-        progress_callback=None, 
-        countries: List[str] = None
+        self, playable_only: bool = True, progress_callback=None, countries: List[str] = None
     ) -> List[Dict[str, Any]]:
         """
         Retrieves all films from MUBI API by syncing across specified countries.
-        
+
         :param playable_only: If True, only fetch currently playable films.
         :param progress_callback: Optional callback function to report progress.
         :param countries: List of ISO 3166-1 alpha-2 country codes to sync from.
@@ -53,6 +53,7 @@ class MubiApiDataSource(FilmDataSource):
             # We need to access settings via xbmcaddon, but to avoid circular imports or extra deps,
             # we can rely on mubi client if it had this info, but mubi client logic was:
             import xbmcaddon
+
             client_country = xbmcaddon.Addon().getSetting("client_country")
             if client_country:
                 countries = [client_country.upper()]
@@ -94,19 +95,18 @@ class MubiApiDataSource(FilmDataSource):
                                 total_films=0,
                                 current_country=c_idx,
                                 total_countries=c_total,
-                                country_code=c_code
+                                country_code=c_code,
                             )
                         except Exception as e:
                             xbmc.log(f"Progress callback exception (user cancel): {e}", xbmc.LOGINFO)
                             user_cancelled = True
                             return False  # Signal to stop fetching
                     return True  # Continue
+
                 return page_callback
 
             base_film_count = len(all_film_ids)
-            page_cb = create_page_callback(
-                country_idx, country, len(countries), base_film_count, running_new_films
-            )
+            page_cb = create_page_callback(country_idx, country, len(countries), base_film_count, running_new_films)
 
             # Initial progress update before fetching
             if progress_callback:
@@ -116,7 +116,7 @@ class MubiApiDataSource(FilmDataSource):
                         total_films=0,
                         current_country=country_idx,
                         total_countries=len(countries),
-                        country_code=country
+                        country_code=country,
                     )
                 except Exception as e:
                     xbmc.log(f"Progress callback exception (user cancel): {e}", xbmc.LOGINFO)
@@ -124,13 +124,10 @@ class MubiApiDataSource(FilmDataSource):
 
             # Use the mubi client's internal helper to fetch pages
             # We assume mubi._fetch_films_for_country is still available or we move it here?
-            # Ideally we move it here or make it public. 
+            # Ideally we move it here or make it public.
             # For now, we will access it as protected member since Mubi class is passed in.
             film_ids, film_data, total_count, pages = self.mubi._fetch_films_for_country(
-                country_code=country,
-                playable_only=playable_only,
-                page_callback=page_cb,
-                global_film_ids=all_film_ids
+                country_code=country, playable_only=playable_only, page_callback=page_cb, global_film_ids=all_film_ids
             )
 
             # Check if user cancelled during fetch
@@ -139,10 +136,10 @@ class MubiApiDataSource(FilmDataSource):
 
             # Track statistics
             country_stats[country] = {
-                'total_reported': total_count,
-                'unique_fetched': len(film_ids),
-                'pages': pages,
-                'film_ids': film_ids
+                "total_reported": total_count,
+                "unique_fetched": len(film_ids),
+                "pages": pages,
+                "film_ids": film_ids,
             }
             total_pages_fetched += pages
 
@@ -150,17 +147,17 @@ class MubiApiDataSource(FilmDataSource):
             for film_id in film_ids:
                 if film_id not in film_country_map:
                     film_country_map[film_id] = {}
-                
+
                 # Extract consumable data for this film in this country
                 this_film_data = film_data.get(film_id, {})
-                consumable = this_film_data.get('consumable') or {}  # Handle explicit null
-                
+                consumable = this_film_data.get("consumable") or {}  # Handle explicit null
+
                 if consumable:
                     # Prune playback_languages from country-specific data (now global)
-                    if 'playback_languages' in consumable:
+                    if "playback_languages" in consumable:
                         consumable = consumable.copy()
-                        consumable.pop('playback_languages', None)
-                    
+                        consumable.pop("playback_languages", None)
+
                     film_country_map[film_id][country] = consumable
 
             # Merge new films into all_film_data
@@ -170,19 +167,19 @@ class MubiApiDataSource(FilmDataSource):
                     # Clean the data - remove global 'consumable' if it exists to avoid confusion
                     # We store country-specific consumable data in film_country_map
                     clean_data = data.copy()
-                    
+
                     # EXTRACT PLAYBACK LANGUAGES (Schema Update)
                     # We promote playback_languages to top-level if present in consumable
-                    consumable = clean_data.get('consumable') or {}  # Handle explicit null
-                    if consumable and 'playback_languages' in consumable:
-                        clean_data['playback_languages'] = consumable['playback_languages']
-                    
-                    clean_data.pop('consumable', None) # Remove core consumable
-                    
+                    consumable = clean_data.get("consumable") or {}  # Handle explicit null
+                    if consumable and "playback_languages" in consumable:
+                        clean_data["playback_languages"] = consumable["playback_languages"]
+
+                    clean_data.pop("consumable", None)  # Remove core consumable
+
                     all_film_data[film_id] = clean_data
                     all_film_ids.add(film_id)
                     new_films_count += 1
-            
+
             xbmc.log(f"[{country}] Added {new_films_count} new unique films to merged catalogue", xbmc.LOGINFO)
 
         # Log comprehensive statistics
@@ -193,9 +190,9 @@ class MubiApiDataSource(FilmDataSource):
         for film_id, data in all_film_data.items():
             # We inject the available countries into the raw data dictionary
             # This avoids changing the API structure but allows passing this info along
-            data['available_countries'] = film_country_map.get(film_id, {})
+            data["available_countries"] = film_country_map.get(film_id, {})
             output_list.append(data)
-            
+
         return output_list
 
     def _log_stats(self, countries, total_pages_fetched, all_film_ids, country_stats, film_country_map):
@@ -249,9 +246,9 @@ class GithubDataSource(FilmDataSource):
     def get_films(self, *args, **kwargs) -> List[Dict[str, Any]]:
         """
         Downloads, decompresses, and parses films.json.gz from GitHub.
-        
-        :kwargs countries: List[str] of country codes to filter by (optional). 
-                           If provided, only films available in at least one of these countries 
+
+        :kwargs countries: List[str] of country codes to filter by (optional).
+                           If provided, only films available in at least one of these countries
                            (and currently live/within date range) will be returned.
         """
         import gzip
@@ -262,29 +259,29 @@ class GithubDataSource(FilmDataSource):
         import requests
         from requests.adapters import HTTPAdapter
         from requests.packages.urllib3.util.retry import Retry
-        
+
         xbmc.log(f"Starting GitHub Sync from {self.GITHUB_URL}", xbmc.LOGINFO)
-        
+
         # Configure retry strategy
         retry_strategy = Retry(
             total=3,
             backoff_factor=1,
             status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["HEAD", "GET", "OPTIONS"]
+            allowed_methods=["HEAD", "GET", "OPTIONS"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session = requests.Session()
         session.mount("https://", adapter)
         session.mount("http://", adapter)
-        
+
         try:
             # 1. Download MD5 checksum
             md5_url = self.GITHUB_URL + ".md5"
             xbmc.log(f"Downloading MD5 checksum from {md5_url}", xbmc.LOGINFO)
             md5_response = session.get(md5_url, timeout=10)
             md5_response.raise_for_status()
-            expected_md5 = md5_response.text.strip().split()[0] # Handle potentially "hash filename" format
-            
+            expected_md5 = md5_response.text.strip().split()[0]  # Handle potentially "hash filename" format
+
             # 2. Download the file content
             xbmc.log(f"Downloading database from {self.GITHUB_URL}", xbmc.LOGINFO)
             response = session.get(self.GITHUB_URL, stream=True, timeout=30)
@@ -297,55 +294,57 @@ class GithubDataSource(FilmDataSource):
                 # Log detailed error for debugging
                 xbmc.log(f"MD5 Mismatch! Expected: {expected_md5}, Calculated: {calculated_md5}", xbmc.LOGERROR)
                 raise ValueError(f"MD5 verification failed. Integrity check failed for {self.GITHUB_URL}")
-            
+
             xbmc.log("MD5 verification successful", xbmc.LOGINFO)
 
             # 4. Decompress and parse
             with gzip.GzipFile(fileobj=io.BytesIO(content)) as gz:
                 data = json.load(gz)
-            
+
             # 5. Check version compatibility
             meta = data.get("meta", {})
             version = meta.get("version", 1)
             version_label = meta.get("version_label", "unknown")
-            
+
             if version not in self.SUPPORTED_VERSIONS:
-                xbmc.log(f"Warning: Schema version {version} ({version_label}) not officially supported", xbmc.LOGWARNING)
+                xbmc.log(
+                    f"Warning: Schema version {version} ({version_label}) not officially supported", xbmc.LOGWARNING
+                )
             else:
                 xbmc.log(f"Schema version: {version} ({version_label})", xbmc.LOGINFO)
-            
+
             # 6. Parse films (best-effort - outer exception handler will catch failures)
             films_list = data.get("items", [])
-            
+
             # Normalization: Map 'mubi_id' to 'id' if 'id' is missing
             # The plugin expects 'id'
             for film in films_list:
-                if 'id' not in film and 'mubi_id' in film:
-                    film['id'] = film['mubi_id']
-                
+                if "id" not in film and "mubi_id" in film:
+                    film["id"] = film["mubi_id"]
+
                 # Normalize 'directors' from list of strings to list of dicts
                 # API returns [{'name': 'Director Name'}], GitHub JSON has ['Director Name']
-                if 'directors' in film and isinstance(film['directors'], list):
-                    if film['directors'] and isinstance(film['directors'][0], str):
-                        film['directors'] = [{'name': d} for d in film['directors']]
+                if "directors" in film and isinstance(film["directors"], list):
+                    if film["directors"] and isinstance(film["directors"][0], str):
+                        film["directors"] = [{"name": d} for d in film["directors"]]
 
             xbmc.log(f"Successfully downloaded and parsed {len(films_list)} films from GitHub", xbmc.LOGINFO)
-            
+
             # --- FILTERING LOGIC ---
-            target_countries = kwargs.get('countries')
+            target_countries = kwargs.get("countries")
             if target_countries:
                 # Normalize countries to uppercase
                 target_countries = [c.upper() for c in target_countries]
                 xbmc.log(f"Filtering films for countries: {target_countries}", xbmc.LOGINFO)
-                
+
                 filtered_list = []
                 now = datetime.datetime.now(datetime.timezone.utc)
-                
+
                 for film in films_list:
-                    available_countries = film.get('available_countries', {})
+                    available_countries = film.get("available_countries", {})
                     if not available_countries:
                         continue
-                        
+
                     is_available = False
 
                     # Check if film is available in ANY of the target countries.
@@ -357,11 +356,11 @@ class GithubDataSource(FilmDataSource):
                             details = available_countries[country_code]
                             if is_country_available(details, now):
                                 is_available = True
-                                break # Found a valid country, keep the film
-                    
+                                break  # Found a valid country, keep the film
+
                     if is_available:
                         filtered_list.append(film)
-                
+
                 xbmc.log(f"Filtered count: {len(filtered_list)} (from {len(films_list)} total)", xbmc.LOGINFO)
                 return filtered_list
 
@@ -378,4 +377,3 @@ class GithubDataSource(FilmDataSource):
             raise
         finally:
             session.close()
-

--- a/repo/plugin_video_mubi/resources/lib/data_source.py
+++ b/repo/plugin_video_mubi/resources/lib/data_source.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-import xbmc
-import time
-from typing import List, Dict, Any, Callable
-from abc import ABC, abstractmethod
-
 import datetime
+from typing import Any, Dict, List
+
+import xbmc
 
 try:
-    from .constants import CATALOG_FILMS_URL
     from .availability import is_country_available
+    from .constants import CATALOG_FILMS_URL
 except ImportError:  # imported as a top-level module (e.g. some test harnesses)
-    from constants import CATALOG_FILMS_URL
     from availability import is_country_available
+    from constants import CATALOG_FILMS_URL
 
 class FilmDataSource:
     """
@@ -70,10 +68,10 @@ class MubiApiDataSource(FilmDataSource):
         film_country_map = {}  # {film_id: {country: consumable_data}}
         total_pages_fetched = 0
 
-        xbmc.log(f"=" * 60, xbmc.LOGINFO)
-        xbmc.log(f"MULTI-COUNTRY CATALOGUE SYNC (DataSource)", xbmc.LOGINFO)
+        xbmc.log("=" * 60, xbmc.LOGINFO)
+        xbmc.log("MULTI-COUNTRY CATALOGUE SYNC (DataSource)", xbmc.LOGINFO)
         xbmc.log(f"Countries to sync: {', '.join(countries)} ({len(countries)} total)", xbmc.LOGINFO)
-        xbmc.log(f"=" * 60, xbmc.LOGINFO)
+        xbmc.log("=" * 60, xbmc.LOGINFO)
 
         # Fetch films from each country
         for country_idx, country in enumerate(countries, 1):
@@ -201,17 +199,17 @@ class MubiApiDataSource(FilmDataSource):
         return output_list
 
     def _log_stats(self, countries, total_pages_fetched, all_film_ids, country_stats, film_country_map):
-        xbmc.log(f"", xbmc.LOGINFO)
-        xbmc.log(f"=" * 60, xbmc.LOGINFO)
-        xbmc.log(f"MULTI-COUNTRY SYNC STATISTICS", xbmc.LOGINFO)
-        xbmc.log(f"=" * 60, xbmc.LOGINFO)
+        xbmc.log("", xbmc.LOGINFO)
+        xbmc.log("=" * 60, xbmc.LOGINFO)
+        xbmc.log("MULTI-COUNTRY SYNC STATISTICS", xbmc.LOGINFO)
+        xbmc.log("=" * 60, xbmc.LOGINFO)
         xbmc.log(f"Countries synced: {len(countries)}", xbmc.LOGINFO)
         xbmc.log(f"Total pages fetched: {total_pages_fetched}", xbmc.LOGINFO)
         xbmc.log(f"Total unique films: {len(all_film_ids)}", xbmc.LOGINFO)
-        xbmc.log(f"", xbmc.LOGINFO)
+        xbmc.log("", xbmc.LOGINFO)
 
         # Per-country stats
-        xbmc.log(f"--- Per-Country Breakdown ---", xbmc.LOGINFO)
+        xbmc.log("--- Per-Country Breakdown ---", xbmc.LOGINFO)
         for country, stats in country_stats.items():
             xbmc.log(f"  {country}: {stats['unique_fetched']} films ({stats['pages']} pages)", xbmc.LOGINFO)
 
@@ -228,15 +226,15 @@ class MubiApiDataSource(FilmDataSource):
                     films_country_exclusive[country] = set()
                 films_country_exclusive[country].add(film_id)
 
-        xbmc.log(f"", xbmc.LOGINFO)
-        xbmc.log(f"--- Availability Analysis ---", xbmc.LOGINFO)
+        xbmc.log("", xbmc.LOGINFO)
+        xbmc.log("--- Availability Analysis ---", xbmc.LOGINFO)
         xbmc.log(f"Films available in ALL {len(countries)} countries: {len(films_in_all)}", xbmc.LOGINFO)
 
         for country in countries:
             exclusive = films_country_exclusive.get(country, set())
             xbmc.log(f"Films EXCLUSIVE to {country}: {len(exclusive)}", xbmc.LOGINFO)
 
-        xbmc.log(f"=" * 60, xbmc.LOGINFO)
+        xbmc.log("=" * 60, xbmc.LOGINFO)
 
 
 class GithubDataSource(FilmDataSource):
@@ -256,13 +254,14 @@ class GithubDataSource(FilmDataSource):
                            If provided, only films available in at least one of these countries 
                            (and currently live/within date range) will be returned.
         """
+        import gzip
+        import hashlib
+        import io
+        import json
+
         import requests
         from requests.adapters import HTTPAdapter
         from requests.packages.urllib3.util.retry import Retry
-        import hashlib
-        import gzip
-        import json
-        import io
         
         xbmc.log(f"Starting GitHub Sync from {self.GITHUB_URL}", xbmc.LOGINFO)
         

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/__init__.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/__init__.py
@@ -1,11 +1,10 @@
 """External metadata provider utilities."""
 
 from .base import BaseMetadataProvider, ExternalMetadataResult
-
 from .factory import MetadataProviderFactory
 from .omdb_provider import OMDBProvider
-from .tmdb_provider import TMDBProvider
 from .title_utils import RetryStrategy, TitleNormalizer
+from .tmdb_provider import TMDBProvider
 
 __all__ = [
     "BaseMetadataProvider",

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/factory.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/factory.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Optional
+
 import xbmc
 import xbmcaddon
 
 from .base import BaseMetadataProvider
 from .omdb_provider import OMDBProvider
 from .tmdb_provider import TMDBProvider
-
-
-
-
 
 
 class MetadataProviderFactory:

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/factory.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/factory.py
@@ -13,13 +13,13 @@ from .tmdb_provider import TMDBProvider
 class MetadataProviderFactory:
     """
     Factory for creating metadata provider instances.
-    
+
     Implements automatic provider selection based on API key availability:
     - TMDB preferred when available
     - Falls back to OMDB if only OMDB key available
     - Returns None if no keys configured
     """
-    
+
     @staticmethod
     def _get_api_keys() -> tuple[str, str]:
         """Retrieve API keys from addon settings."""
@@ -36,7 +36,7 @@ class MetadataProviderFactory:
     def validate_configuration() -> bool:
         """
         Check if at least one provider is configured.
-        
+
         :return: True if a provider is ready, False otherwise.
         """
         omdb_key, tmdb_key = MetadataProviderFactory._get_api_keys()
@@ -51,39 +51,26 @@ class MetadataProviderFactory:
     def get_provider() -> Optional[BaseMetadataProvider]:
         """
         Automatically select and instantiate the best available provider.
-        
+
         Selection priority:
         1. TMDB (if TMDB API key available) - preferred provider
         2. OMDB (if OMDB API key available) - fallback provider
         3. None (if no keys available) - graceful degradation
-        
+
         :return: Provider instance or None
         """
         omdb_key, tmdb_key = MetadataProviderFactory._get_api_keys()
-        
+
         # Priority 1: TMDB (preferred when available)
         if tmdb_key:
-            xbmc.log(
-                "External metadata: Using TMDB provider",
-                xbmc.LOGINFO
-            )
+            xbmc.log("External metadata: Using TMDB provider", xbmc.LOGINFO)
             return TMDBProvider(api_key=tmdb_key)
-        
+
         # Priority 3: OMDB (fallback for existing users)
         if omdb_key:
-            xbmc.log(
-                "External metadata: Using OMDB provider",
-                xbmc.LOGINFO
-            )
+            xbmc.log("External metadata: Using OMDB provider", xbmc.LOGINFO)
             return OMDBProvider(api_key=omdb_key)
-        
+
         # Priority 4: No provider available
-        xbmc.log(
-            "External metadata: No provider available - no API keys configured",
-            xbmc.LOGWARNING
-        )
+        xbmc.log("External metadata: No provider available - no API keys configured", xbmc.LOGWARNING)
         return None
-    
-
-
-

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/omdb_provider.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/omdb_provider.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, Optional
 import requests
 import xbmc
 
-from ..constants import OMDB_API_URL, IMDB_TITLE_URL_TEMPLATE
+from ..constants import IMDB_TITLE_URL_TEMPLATE, OMDB_API_URL
 from .base import BaseMetadataProvider, ExternalMetadataResult
-from .title_utils import TitleNormalizer, RetryStrategy, redact_secrets
+from .title_utils import RetryStrategy, TitleNormalizer, redact_secrets
 
 
 class OMDBProvider(BaseMetadataProvider):

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/omdb_provider.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/omdb_provider.py
@@ -26,8 +26,6 @@ class OMDBProvider(BaseMetadataProvider):
             secrets=(self.api_key,),
         )
 
-
-
     @property
     def provider_name(self) -> str:
         return "OMDB"
@@ -40,12 +38,10 @@ class OMDBProvider(BaseMetadataProvider):
         media_type: str = "movie",
     ) -> ExternalMetadataResult:
 
-
         variants = self.title_normalizer.generate_title_variants(title, original_title)
         for variant in variants:
             result = self._request_with_retry(variant, year, media_type)
             if result.success:
-
                 return result
 
         xbmc.log(
@@ -58,8 +54,6 @@ class OMDBProvider(BaseMetadataProvider):
             source_provider=self.provider_name,
             error_message="No match found",
         )
-
-
 
         return result
 

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/title_utils.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/title_utils.py
@@ -121,7 +121,7 @@ class TitleNormalizer:
                 # But 'Color' -> 'Colour', 'color' -> 'colour'.
                 # Naive replacement:
                 pattern = re.compile(re.escape(word), re.IGNORECASE)
-                
+
                 def replace_case_match(match):
                     g = match.group()
                     if g.isupper():
@@ -131,7 +131,7 @@ class TitleNormalizer:
                     return replacement
 
                 new_title = pattern.sub(replace_case_match, title)
-                
+
                 # Verify we actually changed something and it's not effectively same
                 if new_title.lower() != title.lower() and new_title not in alternatives:
                     alternatives.append(new_title)
@@ -149,11 +149,11 @@ class TitleNormalizer:
             r"Redux",
             r"\[MV\]",  # Music Video
         ]
-        
+
         cleaned = title
         for pattern in patterns:
             cleaned = re.sub(pattern, "", cleaned, flags=re.IGNORECASE)
-            
+
         return re.sub(r"\s+", " ", cleaned).strip()
 
     def generate_title_variants(
@@ -165,10 +165,10 @@ class TitleNormalizer:
         variants: List[str] = []
 
         normalized_title = title.strip()
-        
+
         # 1. Original MUBI title
         variants.append(normalized_title)
-        
+
         # 2. Original title (from metadata)
         if original_title and original_title.strip().lower() != normalized_title.lower():
             variants.append(original_title.strip())
@@ -234,7 +234,7 @@ class RetryStrategy:
                 if status_code in [401, 402, 429]:
                     retry_after = error.response.headers.get("Retry-After")
                     wait_time = backoff
-                    
+
                     if retry_after:
                         try:
                             wait_time = float(retry_after) + 1  # Add small buffer

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/tmdb_provider.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/tmdb_provider.py
@@ -13,20 +13,20 @@ from .title_utils import RetryStrategy, TitleNormalizer, redact_secrets
 class TMDBProvider(BaseMetadataProvider):
     """
     TMDB metadata provider.
-    
+
     Advantages over OMDB:
     - Returns both IMDB ID and TMDB ID
     - Multiple search results for better matching
     - Better support for international titles
     - Free API with higher rate limits
     """
-    
+
     BASE_URL = TMDB_API_URL
-    
+
     def __init__(self, api_key: str, config: Optional[Dict[str, Any]] = None) -> None:
         """Initialize TMDB provider with API key."""
         super().__init__(api_key, config)
-        
+
         self.title_normalizer = TitleNormalizer()
         self.retry_strategy = RetryStrategy(
             max_retries=self.config.get("max_retries", 3),
@@ -34,47 +34,40 @@ class TMDBProvider(BaseMetadataProvider):
             multiplier=self.config.get("backoff_multiplier", 1.5),
             secrets=(self.api_key,),
         )
-        
-
 
     @property
     def provider_name(self) -> str:
         return "TMDB"
-    
+
     def get_imdb_id(
-        self,
-        title: str,
-        original_title: Optional[str] = None,
-        year: Optional[int] = None,
-        media_type: str = "movie"
+        self, title: str, original_title: Optional[str] = None, year: Optional[int] = None, media_type: str = "movie"
     ) -> ExternalMetadataResult:
         """
         Fetch IMDB ID and TMDB ID from TMDB.
-        
+
         Returns ExternalMetadataResult with:
         - imdb_id: IMDB identifier (e.g., "tt0133093")
         - tmdb_id: TMDB identifier (e.g., "603")
         - source_provider: "TMDB"
         """
 
-
         # Generate search candidates (Original Title, Title, Variants)
         search_candidates = self.title_normalizer.generate_title_variants(title, original_title)
-        
+
         # Ensure simple title and original title are at the top of the list if not already
         if title not in search_candidates:
-             search_candidates.insert(0, title)
+            search_candidates.insert(0, title)
         if original_title and original_title != title and original_title not in search_candidates:
-             search_candidates.insert(1, original_title)
+            search_candidates.insert(1, original_title)
 
         tmdb_id = None
-        
+
         for candidate in search_candidates:
             # 1. Try strict search with year
             tmdb_id = self._search_movie(candidate, year)
             if tmdb_id:
                 break
-                
+
             # 2. If year provided, try searching WITHOUT year (fuzzy match)
             # This handles cases where MUBI year is off by ±1 year
             if year:
@@ -82,53 +75,42 @@ class TMDBProvider(BaseMetadataProvider):
                 tmdb_id = self._search_movie(candidate, year=None, target_year=year)
                 if tmdb_id:
                     break
-        
+
         if not tmdb_id:
             result = ExternalMetadataResult(
-                success=False,
-                source_provider=self.provider_name,
-                error_message="No match found"
+                success=False, source_provider=self.provider_name, error_message="No match found"
             )
             return result
-            
+
         # Get details to find IMDB ID
         result = self._get_movie_details(tmdb_id)
-        
 
-            
         return result
 
     def _search_movie(self, title: str, year: Optional[int], target_year: Optional[int] = None) -> Optional[int]:
         """
         Search for a movie.
-        
+
         :param title: Title to search for
         :param year: Strict year filter for API
         :param target_year: Use for fuzzy matching when year is None (±1 year tolerance)
         """
-        params = {
-            "api_key": self.api_key,
-            "query": title,
-            "include_adult": "false",
-            "page": 1
-        }
+        params = {"api_key": self.api_key, "query": title, "include_adult": "false", "page": 1}
         if year:
             params["year"] = str(year)
-            
+
         def do_search() -> ExternalMetadataResult:
             response = requests.get(f"{self.BASE_URL}/search/movie", params=params, timeout=10)
             response.raise_for_status()
-            
+
             data = response.json()
             results = data.get("results", [])
-            
+
             if not results:
                 return ExternalMetadataResult(
-                    success=False,
-                    source_provider=self.provider_name,
-                    error_message="No match found"
+                    success=False, source_provider=self.provider_name, error_message="No match found"
                 )
-                
+
             # If target_year is provided (fuzzy search), find best match
             if target_year and not year:
                 for movie in results:
@@ -140,35 +122,31 @@ class TMDBProvider(BaseMetadataProvider):
                             # Check tolerance ±2 year
                             if abs(movie_year - target_year) <= 2:
                                 return ExternalMetadataResult(
-                                    success=True,
-                                    tmdb_id=str(movie["id"]),
-                                    source_provider=self.provider_name
+                                    success=True, tmdb_id=str(movie["id"]), source_provider=self.provider_name
                                 )
                         except (ValueError, IndexError):
                             continue
-                
+
                 # If no match found within tolerance
                 return ExternalMetadataResult(
                     success=False,
                     source_provider=self.provider_name,
-                    error_message=f"No match found within 2 years of {target_year}"
+                    error_message=f"No match found within 2 years of {target_year}",
                 )
-                
+
             # Return the ID of the first result (default strict behavior)
             return ExternalMetadataResult(
-                success=True,
-                tmdb_id=str(results[0]["id"]),
-                source_provider=self.provider_name
+                success=True, tmdb_id=str(results[0]["id"]), source_provider=self.provider_name
             )
 
         try:
             # retry_strategy expects a function that returns ExternalMetadataResult
             result = self.retry_strategy.execute(do_search, title)
-            
+
             if result.success and result.tmdb_id:
                 return int(result.tmdb_id)
             return None
-            
+
         except Exception as e:
             xbmc.log(f"TMDB: Search failed for '{title}': {redact_secrets(e, (self.api_key,))}", xbmc.LOGWARNING)
             return None
@@ -179,48 +157,33 @@ class TMDBProvider(BaseMetadataProvider):
             # We need the external_ids, which can be fetched with append_to_response
             # or via a separate endpoint. append_to_response is efficient.
             url = f"{self.BASE_URL}/movie/{tmdb_id}"
-            params = {
-                "api_key": self.api_key,
-                "append_to_response": "external_ids"
-            }
-            
+            params = {"api_key": self.api_key, "append_to_response": "external_ids"}
+
             response = requests.get(url, params=params, timeout=10)
             response.raise_for_status()
             data = response.json()
-            
+
             external_ids = data.get("external_ids", {})
             imdb_id = external_ids.get("imdb_id")
-            
-            result_data = {
-                "tmdb_id": str(tmdb_id),
-                "source_provider": self.provider_name,
-                "success": True
-            }
-            
+
+            result_data = {"tmdb_id": str(tmdb_id), "source_provider": self.provider_name, "success": True}
+
             if imdb_id:
                 result_data["imdb_id"] = imdb_id
                 result_data["imdb_url"] = IMDB_TITLE_URL_TEMPLATE.format(imdb_id=imdb_id)
-                
+
             return ExternalMetadataResult(**result_data)
-            
+
         except Exception as e:
             # str(e) of a requests error embeds the full URL incl. api_key=... -> redact.
             safe_error = redact_secrets(e, (self.api_key,))
             xbmc.log(f"TMDB: Failed to get details for ID {tmdb_id}: {safe_error}", xbmc.LOGERROR)
-            return ExternalMetadataResult(
-                success=False,
-                source_provider=self.provider_name,
-                error_message=safe_error
-            )
+            return ExternalMetadataResult(success=False, source_provider=self.provider_name, error_message=safe_error)
 
     def test_connection(self) -> bool:
         """Test whether the provider is reachable."""
         try:
-            response = requests.get(
-                f"{self.BASE_URL}/configuration",
-                params={"api_key": self.api_key},
-                timeout=10
-            )
+            response = requests.get(f"{self.BASE_URL}/configuration", params={"api_key": self.api_key}, timeout=10)
             return response.status_code == 200
         except Exception:
             return False

--- a/repo/plugin_video_mubi/resources/lib/external_metadata/tmdb_provider.py
+++ b/repo/plugin_video_mubi/resources/lib/external_metadata/tmdb_provider.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, Optional
 import requests
 import xbmc
 
-from ..constants import TMDB_API_URL, IMDB_TITLE_URL_TEMPLATE
+from ..constants import IMDB_TITLE_URL_TEMPLATE, TMDB_API_URL
 from .base import BaseMetadataProvider, ExternalMetadataResult
-from .title_utils import TitleNormalizer, RetryStrategy, redact_secrets
+from .title_utils import RetryStrategy, TitleNormalizer, redact_secrets
 
 
 class TMDBProvider(BaseMetadataProvider):

--- a/repo/plugin_video_mubi/resources/lib/film.py
+++ b/repo/plugin_video_mubi/resources/lib/film.py
@@ -1,16 +1,15 @@
-import os
-from pathlib import Path
-import xbmc
-import xml.etree.ElementTree as ET
-import requests
-from requests.exceptions import RequestException
-import json
-import time
 import re
-from typing import Optional, List
-from .external_metadata import MetadataProviderFactory
-from .availability import is_country_available
+import time
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+import xbmc
+
+from .availability import is_country_available
+from .external_metadata import MetadataProviderFactory
 
 
 class Film:
@@ -67,7 +66,7 @@ class Film:
         return hash(self.mubi_id)
 
     def _sanitize_filename(self, filename: str) -> str:
-        """
+        r"""
         LEVEL 2 FILESYSTEM SAFETY PROTECTION
 
         Sanitize filename by removing only filesystem-dangerous characters while
@@ -562,7 +561,7 @@ class Film:
             (hasattr(metadata, 'subtitle_languages') and metadata.subtitle_languages) or
             True): # Always create streamdetails for Video flags now
 
-            fileinfo = root_node_check = ET.SubElement(movie, "fileinfo")
+            fileinfo = ET.SubElement(movie, "fileinfo")
             streamdetails = ET.SubElement(fileinfo, "streamdetails")
 
             # Add Video Stream

--- a/repo/plugin_video_mubi/resources/lib/film.py
+++ b/repo/plugin_video_mubi/resources/lib/film.py
@@ -13,8 +13,9 @@ from .external_metadata import MetadataProviderFactory
 
 
 class Film:
-    def __init__(self, mubi_id: str, title: str, artwork: str, web_url: str, metadata,
-                 available_countries: dict = None):
+    def __init__(
+        self, mubi_id: str, title: str, artwork: str, web_url: str, metadata, available_countries: dict = None
+    ):
         if not mubi_id or not metadata:
             raise ValueError("Film must have a mubi_id and metadata")
 
@@ -41,7 +42,7 @@ class Film:
     def is_playable(self) -> bool:
         """
         Check if the film is currently available to play in at least one country.
-        
+
         Logic:
         - Iterates through available_countries.
         - Delegates each country to the shared availability-window check
@@ -60,7 +61,6 @@ class Film:
                 return True
 
         return False
-
 
     def __hash__(self):
         return hash(self.mubi_id)
@@ -94,32 +94,51 @@ class Film:
 
         # LEVEL 2: Remove path traversal sequences (security)
         # Remove any sequence of 2 or more consecutive dots
-        sanitized = re.sub(r'\.{2,}', '', sanitized)
+        sanitized = re.sub(r"\.{2,}", "", sanitized)
 
         # LEVEL 2: Remove ONLY filesystem-dangerous characters
         # These characters cause issues on Windows/Mac/Linux filesystems
-        sanitized = re.sub(r'[<>:"/\\|?*]', '', sanitized)
+        sanitized = re.sub(r'[<>:"/\\|?*]', "", sanitized)
 
         # LEVEL 2: Remove control characters (security)
-        sanitized = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', sanitized)
+        sanitized = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", sanitized)
 
         # LEVEL 2: Remove dangerous Unicode sequences (security)
-        sanitized = re.sub(r'[\u0000-\u001F\u007F-\u009F]', '', sanitized)  # Control chars
+        sanitized = re.sub(r"[\u0000-\u001F\u007F-\u009F]", "", sanitized)  # Control chars
         # Zero-width and directional characters
-        sanitized = re.sub(r'[\u200B-\u200F\u202A-\u202E\u2060-\u206F]', '', sanitized)
-        sanitized = re.sub(r'[\uFEFF\uFFFE\uFFFF]', '', sanitized)  # BOM and non-characters
+        sanitized = re.sub(r"[\u200B-\u200F\u202A-\u202E\u2060-\u206F]", "", sanitized)
+        sanitized = re.sub(r"[\uFEFF\uFFFE\uFFFF]", "", sanitized)  # BOM and non-characters
 
         # LEVEL 2: Handle Windows reserved names
         reserved_names = {
-            "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5",
-            "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4",
-            "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM1",
+            "COM2",
+            "COM3",
+            "COM4",
+            "COM5",
+            "COM6",
+            "COM7",
+            "COM8",
+            "COM9",
+            "LPT1",
+            "LPT2",
+            "LPT3",
+            "LPT4",
+            "LPT5",
+            "LPT6",
+            "LPT7",
+            "LPT8",
+            "LPT9",
         }
         if sanitized.upper() in reserved_names:
             sanitized = f"{sanitized}_"  # Add suffix to avoid reserved name conflict
 
         # LEVEL 2: Normalize whitespace (preserve single spaces)
-        sanitized = re.sub(r'\s+', ' ', sanitized)  # Replace multiple spaces with single space
+        sanitized = re.sub(r"\s+", " ", sanitized)  # Replace multiple spaces with single space
 
         # Strip trailing periods and spaces
         sanitized = sanitized.rstrip(". ")
@@ -172,30 +191,30 @@ class Film:
         # Note: ElementTree automatically escapes XML special characters (&, <, >, etc.)
 
         # Remove control characters that could break XML parsing
-        sanitized = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', sanitized)
+        sanitized = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]", "", sanitized)
 
         # Remove dangerous Unicode sequences
-        sanitized = re.sub(r'[\u0000-\u001F\u007F-\u009F]', '', sanitized)
-        sanitized = re.sub(r'[\u200B-\u200F\u202A-\u202E\u2060-\u206F]', '', sanitized)
-        sanitized = re.sub(r'[\uFEFF\uFFFE\uFFFF]', '', sanitized)
+        sanitized = re.sub(r"[\u0000-\u001F\u007F-\u009F]", "", sanitized)
+        sanitized = re.sub(r"[\u200B-\u200F\u202A-\u202E\u2060-\u206F]", "", sanitized)
+        sanitized = re.sub(r"[\uFEFF\uFFFE\uFFFF]", "", sanitized)
 
         # LEVEL 2: Preserve all normal punctuation for movie titles
         # This includes: ? : & , ' " ( ) + = @ # ~ ! $ % ^ [ ] { } etc.
         # Only remove truly dangerous patterns if needed for security
 
         # SECURITY FIX: Remove dangerous Unicode sequences
-        sanitized = re.sub(r'[\u0000-\u001F\u007F-\u009F]', '', sanitized)  # Control chars
-        sanitized = re.sub(r'[\u200B-\u200F\u202A-\u202E\u2060-\u206F]', '', sanitized)  # Zero-width and directional
-        sanitized = re.sub(r'[\uFEFF\uFFFE\uFFFF]', '', sanitized)  # BOM and non-characters
+        sanitized = re.sub(r"[\u0000-\u001F\u007F-\u009F]", "", sanitized)  # Control chars
+        sanitized = re.sub(r"[\u200B-\u200F\u202A-\u202E\u2060-\u206F]", "", sanitized)  # Zero-width and directional
+        sanitized = re.sub(r"[\uFEFF\uFFFE\uFFFF]", "", sanitized)  # BOM and non-characters
 
         # Remove script tags and javascript URLs
-        sanitized = re.sub(r'(?i)<script[^>]*>.*?</script>', '', sanitized)
-        sanitized = re.sub(r'(?i)javascript:', '', sanitized)
+        sanitized = re.sub(r"(?i)<script[^>]*>.*?</script>", "", sanitized)
+        sanitized = re.sub(r"(?i)javascript:", "", sanitized)
 
         # Remove XML processing instructions and DOCTYPE declarations
-        sanitized = re.sub(r'<\?xml[^>]*\?>', '', sanitized)
-        sanitized = re.sub(r'<!DOCTYPE[^>]*>', '', sanitized)
-        sanitized = re.sub(r'<!ENTITY[^>]*>', '', sanitized)
+        sanitized = re.sub(r"<\?xml[^>]*\?>", "", sanitized)
+        sanitized = re.sub(r"<!DOCTYPE[^>]*>", "", sanitized)
+        sanitized = re.sub(r"<!ENTITY[^>]*>", "", sanitized)
 
         # The XML library will handle proper escaping of &, <, >, etc.
         # when we assign to .text, so we don't need to manually escape those
@@ -242,11 +261,7 @@ class Film:
         film_strm_file = film_path / film_file_name
 
         # Build the query parameters (country info is now in NFO, not STRM)
-        query_params = {
-            'action': 'play_mubi_video',
-            'film_id': self.mubi_id,
-            'web_url': self.web_url
-        }
+        query_params = {"action": "play_mubi_video", "film_id": self.mubi_id, "web_url": self.web_url}
 
         encoded_params = urlencode(query_params)
         kodi_movie_url = f"{base_url}?{encoded_params}"
@@ -273,20 +288,20 @@ class Film:
         try:
             imdb_id = ""
             tmdb_id = ""
-            
+
             # Try to fetch external metadata using the factory's automatic selection
             # Factory now handles configuration internally
             # Skip if explicitly requested (e.g. GitHub sync)
             if not skip_external_metadata:
                 provider = MetadataProviderFactory.get_provider()
-                
+
                 if provider:
-                    time.sleep(1) # Small delay to be nice to APIs
+                    time.sleep(1)  # Small delay to be nice to APIs
                     result = provider.get_imdb_id(
                         title=self.title,
                         original_title=self.metadata.originaltitle,
                         year=self.metadata.year,
-                        media_type="movie"
+                        media_type="movie",
                     )
 
                     if result.success:
@@ -294,18 +309,15 @@ class Film:
                             imdb_id = result.imdb_id
                             xbmc.log(
                                 f"Retrieved IMDB ID for '{self.title}' from {result.source_provider}: {imdb_id}",
-                                xbmc.LOGINFO
+                                xbmc.LOGINFO,
                             )
                         if result.tmdb_id:
                             tmdb_id = result.tmdb_id
-                            xbmc.log(
-                                f"Retrieved TMDB ID for '{self.title}': {tmdb_id}",
-                                xbmc.LOGINFO
-                            )
+                            xbmc.log(f"Retrieved TMDB ID for '{self.title}': {tmdb_id}", xbmc.LOGINFO)
                     else:
                         xbmc.log(
                             f"Could not retrieve external metadata for '{self.title}': {result.error_message}",
-                            xbmc.LOGWARNING
+                            xbmc.LOGWARNING,
                         )
                 else:
                     xbmc.log("Skipping external metadata - no API keys configured", xbmc.LOGINFO)
@@ -366,44 +378,47 @@ class Film:
         """
         Check if the rating in the NFO file matches the current film metadata.
         This is used to detect if an update is needed (e.g., switching from MUBI to Bayesian rating).
-        
+
         :param nfo_file: Path to the existing NFO file.
         :return: True if synced (no update needed), False if mismatch (update needed).
         """
         if not nfo_file.exists():
             return False
-            
+
         try:
             tree = ET.parse(nfo_file)
             root = tree.getroot()
-            
+
             # Find rating elements
             # XML path: movie -> ratings -> rating
             ratings_node = root.find("ratings")
             if ratings_node is None:
                 # No ratings in NFO, but we might have data -> mismatched
                 return False
-                
+
             rating_nodes = ratings_node.findall("rating")
-            
+
             # Logic:
             # 1. If we have Bayesian rating in metadata, we expect a 'bayesian' rating in NFO.
             # 2. If we DON'T have Bayesian rating, we expect a 'MUBI' rating.
-            
-            has_bayesian_metadata = hasattr(self.metadata, 'bayesian_rating') and self.metadata.bayesian_rating is not None
-            
+
+            has_bayesian_metadata = (
+                hasattr(self.metadata, "bayesian_rating") and self.metadata.bayesian_rating is not None
+            )
+
             found_matching_rating = False
-            
+
             for r_node in rating_nodes:
                 name = r_node.get("name")
                 value_node = r_node.find("value")
-                if value_node is None: continue
-                
+                if value_node is None:
+                    continue
+
                 try:
                     value = float(value_node.text)
                 except (ValueError, TypeError):
                     continue
-                    
+
                 if has_bayesian_metadata:
                     if name == "bayesian":
                         # Check if value matches (close enough floating point comparison)
@@ -415,18 +430,22 @@ class Film:
                         if abs(value - float(self.metadata.rating)) < 0.01:
                             found_matching_rating = True
                             break
-                            
+
             if not found_matching_rating:
-                xbmc.log(f"Rating mismatch for '{self.title}'. Metadata has Bayesian={has_bayesian_metadata}. Triggering update.", xbmc.LOGDEBUG)
-                
+                xbmc.log(
+                    f"Rating mismatch for '{self.title}'. Metadata has Bayesian={has_bayesian_metadata}. Triggering update.",
+                    xbmc.LOGDEBUG,
+                )
+
             return found_matching_rating
 
         except Exception as e:
             xbmc.log(f"Error checking rating sync for '{self.title}': {e}", xbmc.LOGWARNING)
             return False
 
-
-    def _get_nfo_tree(self, metadata, kodi_trailer_url: str, imdb_id: str, tmdb_id: str = "", artwork_paths: dict = None) -> bytes:
+    def _get_nfo_tree(
+        self, metadata, kodi_trailer_url: str, imdb_id: str, tmdb_id: str = "", artwork_paths: dict = None
+    ) -> bytes:
         """Generate the NFO XML tree structure, including IMDb ID if available."""
         if not metadata.title:
             raise ValueError("Metadata must contain a title")
@@ -438,10 +457,10 @@ class Film:
         ET.SubElement(movie, "originaltitle").text = self._sanitize_xml_content(metadata.originaltitle)
 
         ratings = ET.SubElement(movie, "ratings")
-        
+
         # Check for Bayesian rating (indicates GitHub sync/enhanced data)
         # Assuming if we have a bayesian_rating, we want to use THAT exclusively
-        if hasattr(metadata, 'bayesian_rating') and metadata.bayesian_rating is not None:
+        if hasattr(metadata, "bayesian_rating") and metadata.bayesian_rating is not None:
             rating = ET.SubElement(ratings, "rating")
             rating.set("name", "bayesian")
             rating.set("max", "10")
@@ -460,11 +479,11 @@ class Film:
         ET.SubElement(movie, "runtime").text = str(metadata.duration)
 
         # Add content rating (age rating)
-        if hasattr(metadata, 'mpaa') and metadata.mpaa and metadata.mpaa.get('US'):
-            ET.SubElement(movie, "mpaa").text = self._sanitize_xml_content(metadata.mpaa['US'])
+        if hasattr(metadata, "mpaa") and metadata.mpaa and metadata.mpaa.get("US"):
+            ET.SubElement(movie, "mpaa").text = self._sanitize_xml_content(metadata.mpaa["US"])
 
         # Add tagline from press_quote (if available)
-        if hasattr(metadata, 'tagline') and metadata.tagline:
+        if hasattr(metadata, "tagline") and metadata.tagline:
             ET.SubElement(movie, "tagline").text = self._sanitize_xml_content(metadata.tagline)
 
         # Support multiple country tags (previously only used first)
@@ -481,11 +500,11 @@ class Film:
         ET.SubElement(movie, "year").text = str(metadata.year)
 
         # Add premiered date (Kodi v20+ prefers this over deprecated <year>)
-        if hasattr(metadata, 'premiered') and metadata.premiered:
+        if hasattr(metadata, "premiered") and metadata.premiered:
             ET.SubElement(movie, "premiered").text = self._sanitize_xml_content(metadata.premiered)
 
         # Add content warnings as library tags
-        if hasattr(metadata, 'content_warnings') and metadata.content_warnings:
+        if hasattr(metadata, "content_warnings") and metadata.content_warnings:
             for warning in metadata.content_warnings:
                 if warning and str(warning).strip():
                     ET.SubElement(movie, "tag").text = self._sanitize_xml_content(str(warning).strip())
@@ -499,68 +518,67 @@ class Film:
         # Thumbnail/Landscape artwork
         thumb = ET.SubElement(movie, "thumb")
         thumb.set("aspect", "landscape")
-        if 'thumb' in artwork_paths and Path(artwork_paths['thumb']).exists():
-            thumb.text = Path(artwork_paths['thumb']).name
+        if "thumb" in artwork_paths and Path(artwork_paths["thumb"]).exists():
+            thumb.text = Path(artwork_paths["thumb"]).name
             xbmc.log(f"Using local thumbnail: {Path(artwork_paths['thumb']).name}", xbmc.LOGDEBUG)
         else:
             thumb.text = metadata.image
             xbmc.log(f"Using remote thumbnail URL: {metadata.image}", xbmc.LOGDEBUG)
 
         # Poster artwork (vertical)
-        if artwork_paths and 'poster' in artwork_paths and Path(artwork_paths['poster']).exists():
+        if artwork_paths and "poster" in artwork_paths and Path(artwork_paths["poster"]).exists():
             poster = ET.SubElement(movie, "poster")
-            poster.text = Path(artwork_paths['poster']).name
+            poster.text = Path(artwork_paths["poster"]).name
             xbmc.log(f"Using local poster: {Path(artwork_paths['poster']).name}", xbmc.LOGDEBUG)
 
         # Fanart artwork (background)
-        if artwork_paths and 'fanart' in artwork_paths and Path(artwork_paths['fanart']).exists():
+        if artwork_paths and "fanart" in artwork_paths and Path(artwork_paths["fanart"]).exists():
             fanart = ET.SubElement(movie, "fanart")
             fanart_thumb = ET.SubElement(fanart, "thumb")
-            fanart_thumb.text = Path(artwork_paths['fanart']).name
+            fanart_thumb.text = Path(artwork_paths["fanart"]).name
             xbmc.log(f"Using local fanart: {Path(artwork_paths['fanart']).name}", xbmc.LOGDEBUG)
 
         # Clear logo (transparent title)
-        if (artwork_paths and 'clearlogo' in artwork_paths
-                and Path(artwork_paths['clearlogo']).exists()):
+        if artwork_paths and "clearlogo" in artwork_paths and Path(artwork_paths["clearlogo"]).exists():
             clearlogo = ET.SubElement(movie, "clearlogo")
-            clearlogo.text = Path(artwork_paths['clearlogo']).name
-            clearlogo_name = Path(artwork_paths['clearlogo']).name
+            clearlogo.text = Path(artwork_paths["clearlogo"]).name
+            clearlogo_name = Path(artwork_paths["clearlogo"]).name
             xbmc.log(f"Using local clearlogo: {clearlogo_name}", xbmc.LOGDEBUG)
 
         # Banner artwork (horizontal wide image for list views)
-        if (artwork_paths and 'banner' in artwork_paths
-                and Path(artwork_paths['banner']).exists()):
+        if artwork_paths and "banner" in artwork_paths and Path(artwork_paths["banner"]).exists():
             banner = ET.SubElement(movie, "banner")
-            banner.text = Path(artwork_paths['banner']).name
+            banner.text = Path(artwork_paths["banner"]).name
             xbmc.log(f"Using local banner: {Path(artwork_paths['banner']).name}", xbmc.LOGDEBUG)
 
         ET.SubElement(movie, "dateadded").text = self._sanitize_xml_content(str(metadata.dateadded))
 
         # Add detailed stream formatting for Media Flags (Resolution, Codec, Audio Channels)
         # Parse media_features (e.g., ["4k", "5.1", "hdr"]) to guess technical details
-        media_features = [str(f).lower() for f in getattr(metadata, 'media_features', []) if f]
-        
+        media_features = [str(f).lower() for f in getattr(metadata, "media_features", []) if f]
+
         # --- VIDEO DETAILS ---
         # Default to 1080p/h264 if not specified
         video_width = "1920"
         video_height = "1080"
         video_codec = "h264"
-        video_aspect = "1.78" # 16:9 assumption
-        
+        video_aspect = "1.78"  # 16:9 assumption
+
         if "4k" in media_features or "uhd" in media_features:
             video_width = "3840"
             video_height = "2160"
-            video_codec = "h265" # Assume HEVC for 4K
+            video_codec = "h265"  # Assume HEVC for 4K
         elif "720p" in media_features:
             video_width = "1280"
             video_height = "720"
-            
+
         # Audio and subtitle language information using official Kodi structure
         # Only add fileinfo/streamdetails if we have data to write
-        if ((hasattr(metadata, 'audio_languages') and metadata.audio_languages) or
-            (hasattr(metadata, 'subtitle_languages') and metadata.subtitle_languages) or
-            True): # Always create streamdetails for Video flags now
-
+        if (
+            (hasattr(metadata, "audio_languages") and metadata.audio_languages)
+            or (hasattr(metadata, "subtitle_languages") and metadata.subtitle_languages)
+            or True
+        ):  # Always create streamdetails for Video flags now
             fileinfo = ET.SubElement(movie, "fileinfo")
             streamdetails = ET.SubElement(fileinfo, "streamdetails")
 
@@ -572,41 +590,43 @@ class Film:
             ET.SubElement(video_elem, "height").text = video_height
             # Add duration in seconds (optional but good for flags)
             if metadata.duration:
-                 ET.SubElement(video_elem, "durationinseconds").text = str(metadata.duration * 60) # duration is usually in mins
-            
+                ET.SubElement(video_elem, "durationinseconds").text = str(
+                    metadata.duration * 60
+                )  # duration is usually in mins
+
             # Add HDR flag if present
             if "hdr" in media_features or "dolby vision" in media_features:
-                 # "hdr10" or "dolbyvision" usually triggers flags
-                 hdr_type = "hdr10"
-                 if "dolby vision" in media_features:
-                     hdr_type = "dolbyvision"
-                 ET.SubElement(video_elem, "hdrtype").text = hdr_type
+                # "hdr10" or "dolbyvision" usually triggers flags
+                hdr_type = "hdr10"
+                if "dolby vision" in media_features:
+                    hdr_type = "dolbyvision"
+                ET.SubElement(video_elem, "hdrtype").text = hdr_type
 
             # --- AUDIO DETAILS ---
             # Audio streams - create separate <audio> element for each language
             # Includes channel information mapped from media_features or audio_channels
-            if hasattr(metadata, 'audio_languages') and metadata.audio_languages:
-                audio_channels_list = getattr(metadata, 'audio_channels', [])
-                
+            if hasattr(metadata, "audio_languages") and metadata.audio_languages:
+                audio_channels_list = getattr(metadata, "audio_channels", [])
+
                 # Check for global audio features if per-track info isn't specific enough
                 global_channels = "2"
                 global_codec = "aac"
-                
+
                 if "5.1" in media_features:
                     global_channels = "6"
-                    global_codec = "eac3" # DD+ is standard for 5.1 streaming
+                    global_codec = "eac3"  # DD+ is standard for 5.1 streaming
                 elif "7.1" in media_features:
                     global_channels = "8"
                     global_codec = "eac3"
                 elif "atmos" in media_features:
-                    global_channels = "8" # Atmos usually piggybacks on 7.1 eac3
+                    global_channels = "8"  # Atmos usually piggybacks on 7.1 eac3
                     global_codec = "eac3"
-                
+
                 for i, lang in enumerate(metadata.audio_languages):
                     if lang and str(lang).strip():  # Skip empty/None values
                         audio_elem = ET.SubElement(streamdetails, "audio")
                         audio_lang = ET.SubElement(audio_elem, "language")
-                        
+
                         # Fix Media Flags: Convert full language name to ISO 639-2 code
                         # User Request: Default back to sanitizing raw input instead of converting
                         audio_lang.text = self._sanitize_xml_content(str(lang).strip())
@@ -614,28 +634,28 @@ class Film:
                         # Determine channels for this specific track
                         channels_text = global_channels
                         codec_text = global_codec
-                        
+
                         # Override with specific track info if available
                         if i < len(audio_channels_list) and audio_channels_list[i]:
                             channel_str = str(audio_channels_list[i]).strip().lower()
-                            if channel_str == '5.1':
-                                channels_text = '6'
-                                codec_text = 'eac3'
-                            elif channel_str == '7.1':
-                                channels_text = '8'
-                                codec_text = 'eac3'
-                            elif channel_str in ('stereo', '2.0'):
-                                channels_text = '2'
-                                codec_text = 'aac'
-                            elif channel_str in ('mono', '1.0'):
-                                channels_text = '1'
-                                codec_text = 'aac'
-                            
+                            if channel_str == "5.1":
+                                channels_text = "6"
+                                codec_text = "eac3"
+                            elif channel_str == "7.1":
+                                channels_text = "8"
+                                codec_text = "eac3"
+                            elif channel_str in ("stereo", "2.0"):
+                                channels_text = "2"
+                                codec_text = "aac"
+                            elif channel_str in ("mono", "1.0"):
+                                channels_text = "1"
+                                codec_text = "aac"
+
                         ET.SubElement(audio_elem, "channels").text = channels_text
                         ET.SubElement(audio_elem, "codec").text = codec_text
 
             # Subtitle streams - create separate <subtitle> element for each language
-            if hasattr(metadata, 'subtitle_languages') and metadata.subtitle_languages:
+            if hasattr(metadata, "subtitle_languages") and metadata.subtitle_languages:
                 for lang in metadata.subtitle_languages:
                     if lang and str(lang).strip():  # Skip empty/None values
                         subtitle_elem = ET.SubElement(streamdetails, "subtitle")
@@ -661,7 +681,7 @@ class Film:
             uid.set("type", "imdb")
             # Removed default="true" - MUBI ID must be default
             uid.text = self._sanitize_xml_content(imdb_id)
-        
+
         # Add TMDB ID if available
         if tmdb_id:
             uid_tmdb = ET.SubElement(movie, "uniqueid")
@@ -697,29 +717,33 @@ class Film:
             country_elem = ET.SubElement(mubi_availability, "country")
             # Store ISO code as attribute
             country_elem.set("code", self._sanitize_xml_content(country_code.upper()))
-            
+
             # Look up full country name
             country_data = COUNTRIES.get(country_code.lower(), {})
             country_name = country_data.get("name", country_code)
-            
+
             # Add Name
             ET.SubElement(country_elem, "name").text = self._sanitize_xml_content(country_name)
-            
+
             # Add Availability Details if present
-            if not details: 
+            if not details:
                 continue
 
-            if 'availability' in details:
-                 ET.SubElement(country_elem, "availability").text = self._sanitize_xml_content(details['availability'])
-            
-            if 'available_at' in details:
-                 ET.SubElement(country_elem, "available_at").text = self._sanitize_xml_content(str(details['available_at']))
-            
-            if 'expires_at' in details:
-                 ET.SubElement(country_elem, "expires_at").text = self._sanitize_xml_content(str(details['expires_at']))
+            if "availability" in details:
+                ET.SubElement(country_elem, "availability").text = self._sanitize_xml_content(details["availability"])
 
-            if 'availability_ends_at' in details:
-                 ET.SubElement(country_elem, "availability_ends_at").text = self._sanitize_xml_content(str(details['availability_ends_at']))
+            if "available_at" in details:
+                ET.SubElement(country_elem, "available_at").text = self._sanitize_xml_content(
+                    str(details["available_at"])
+                )
+
+            if "expires_at" in details:
+                ET.SubElement(country_elem, "expires_at").text = self._sanitize_xml_content(str(details["expires_at"]))
+
+            if "availability_ends_at" in details:
+                ET.SubElement(country_elem, "availability_ends_at").text = self._sanitize_xml_content(
+                    str(details["availability_ends_at"])
+                )
 
     def _download_thumbnail(self, film_path: Path, film_folder_name: str) -> Optional[str]:
         """
@@ -736,14 +760,14 @@ class Film:
         try:
             # Determine file extension from URL
             image_url = self.metadata.image
-            if '.jpg' in image_url.lower():
-                extension = '.jpg'
-            elif '.png' in image_url.lower():
-                extension = '.png'
-            elif '.jpeg' in image_url.lower():
-                extension = '.jpeg'
+            if ".jpg" in image_url.lower():
+                extension = ".jpg"
+            elif ".png" in image_url.lower():
+                extension = ".png"
+            elif ".jpeg" in image_url.lower():
+                extension = ".jpeg"
             else:
-                extension = '.jpg'  # Default fallback
+                extension = ".jpg"  # Default fallback
 
             # Create local thumbnail filename following Kodi conventions
             thumbnail_filename = f"{film_folder_name}-thumb{extension}"
@@ -760,7 +784,7 @@ class Film:
             response.raise_for_status()
 
             # Save the thumbnail locally
-            with open(local_thumbnail_path, 'wb') as f:
+            with open(local_thumbnail_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
                     f.write(chunk)
 
@@ -791,22 +815,22 @@ class Film:
 
                 try:
                     # Determine file extension
-                    if '.jpg' in url.lower():
-                        extension = '.jpg'
-                    elif '.png' in url.lower():
-                        extension = '.png'
-                    elif '.jpeg' in url.lower():
-                        extension = '.jpeg'
+                    if ".jpg" in url.lower():
+                        extension = ".jpg"
+                    elif ".png" in url.lower():
+                        extension = ".png"
+                    elif ".jpeg" in url.lower():
+                        extension = ".jpeg"
                     else:
-                        extension = '.jpg'  # Default fallback
+                        extension = ".jpg"  # Default fallback
 
                     # Create filename following Kodi conventions
-                    if artwork_type == 'thumb':
+                    if artwork_type == "thumb":
                         filename = f"{film_folder_name}-thumb{extension}"
-                    elif artwork_type == 'poster':
+                    elif artwork_type == "poster":
                         filename = f"{film_folder_name}-poster{extension}"
 
-                    elif artwork_type == 'clearlogo':
+                    elif artwork_type == "clearlogo":
                         filename = f"{film_folder_name}-clearlogo{extension}"
                     else:
                         filename = f"{film_folder_name}-{artwork_type}{extension}"
@@ -815,7 +839,9 @@ class Film:
 
                     # Skip download if file already exists
                     if local_path.exists():
-                        xbmc.log(f"{artwork_type.title()} already exists for '{self.title}': {local_path}", xbmc.LOGDEBUG)
+                        xbmc.log(
+                            f"{artwork_type.title()} already exists for '{self.title}': {local_path}", xbmc.LOGDEBUG
+                        )
                         artwork_paths[artwork_type] = str(local_path)
                         continue
 
@@ -825,12 +851,14 @@ class Film:
                     response.raise_for_status()
 
                     # Save the artwork locally
-                    with open(local_path, 'wb') as f:
+                    with open(local_path, "wb") as f:
                         for chunk in response.iter_content(chunk_size=8192):
                             f.write(chunk)
 
                     artwork_paths[artwork_type] = str(local_path)
-                    xbmc.log(f"Successfully downloaded {artwork_type} for '{self.title}' to {local_path}", xbmc.LOGDEBUG)
+                    xbmc.log(
+                        f"Successfully downloaded {artwork_type} for '{self.title}' to {local_path}", xbmc.LOGDEBUG
+                    )
 
                 except Exception as e:
                     xbmc.log(f"Failed to download {artwork_type} for '{self.title}': {e}", xbmc.LOGWARNING)
@@ -851,11 +879,11 @@ class Film:
         artwork_urls = {}
 
         # Get artwork URLs from metadata
-        if hasattr(self.metadata, 'artwork_urls') and self.metadata.artwork_urls:
+        if hasattr(self.metadata, "artwork_urls") and self.metadata.artwork_urls:
             artwork_urls.update(self.metadata.artwork_urls)
 
         # Always include the main image as thumb
         if self.metadata.image:
-            artwork_urls['thumb'] = self.metadata.image
+            artwork_urls["thumb"] = self.metadata.image
 
         return artwork_urls

--- a/repo/plugin_video_mubi/resources/lib/filters.py
+++ b/repo/plugin_video_mubi/resources/lib/filters.py
@@ -19,29 +19,29 @@ class FilmFilter:
         Build list of genres to skip based on toggle settings
         """
         addon = xbmcaddon.Addon()
-        
+
         # Map setting IDs to genre names (lowercase for comparison)
         genre_settings = {
-            'skip_genre_action': 'action',
-            'skip_genre_adventure': 'adventure',
-            'skip_genre_animation': 'animation',
-            'skip_genre_avant_garde': 'avant-garde',
-            'skip_genre_comedy': 'comedy',
-            'skip_genre_commercial': 'commercial',
-            'skip_genre_crime': 'crime',
-            'skip_genre_cult': 'cult',
-            'skip_genre_documentary': 'documentary',
-            'skip_genre_drama': 'drama',
-            'skip_genre_erotica': 'erotica',
-            'skip_genre_fantasy': 'fantasy',
-            'skip_genre_horror': 'horror',
-            'skip_genre_lgbtq': 'lgbtq+',
-            'skip_genre_mystery': 'mystery',
-            'skip_genre_romance': 'romance',
-            'skip_genre_sci_fi': 'sci-fi',
-            'skip_genre_short': 'short',
-            'skip_genre_thriller': 'thriller',
-            'skip_genre_tv_movie': 'tv movie',
+            "skip_genre_action": "action",
+            "skip_genre_adventure": "adventure",
+            "skip_genre_animation": "animation",
+            "skip_genre_avant_garde": "avant-garde",
+            "skip_genre_comedy": "comedy",
+            "skip_genre_commercial": "commercial",
+            "skip_genre_crime": "crime",
+            "skip_genre_cult": "cult",
+            "skip_genre_documentary": "documentary",
+            "skip_genre_drama": "drama",
+            "skip_genre_erotica": "erotica",
+            "skip_genre_fantasy": "fantasy",
+            "skip_genre_horror": "horror",
+            "skip_genre_lgbtq": "lgbtq+",
+            "skip_genre_mystery": "mystery",
+            "skip_genre_romance": "romance",
+            "skip_genre_sci_fi": "sci-fi",
+            "skip_genre_short": "short",
+            "skip_genre_thriller": "thriller",
+            "skip_genre_tv_movie": "tv movie",
         }
 
         skip_genres = []
@@ -55,7 +55,7 @@ class FilmFilter:
     def filter_films(self, films_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Filter out films that match the skip genres.
-        
+
         :param films_data: List of raw film data dictionaries.
         :return: Filtered list of film data.
         """
@@ -63,26 +63,26 @@ class FilmFilter:
             return films_data
 
         initial_count = len(films_data)
-        
+
         filtered_films = []
         for film in films_data:
             # Check if any of the film's genres matches the skip list
             # The structure of 'genres' in raw API response is usually a list of strings
             # In some Mubi API responses it might be objects, but from scraper.py/mubi.py it seems to be list
-            
+
             # Safe extraction
-            film_genres = film.get('genres') or []
-            
+            film_genres = film.get("genres") or []
+
             # Normalize to lower case for comparison
             film_genres_lower = [g.lower() for g in film_genres]
-            
+
             should_skip = any(skip_g in film_genres_lower for skip_g in self.skip_genres)
-            
+
             if not should_skip:
                 filtered_films.append(film)
 
         removed_count = initial_count - len(filtered_films)
         if removed_count > 0:
             xbmc.log(f"FilmFilter: Removed {removed_count} films based on genre filtering.", xbmc.LOGINFO)
-            
+
         return filtered_films

--- a/repo/plugin_video_mubi/resources/lib/filters.py
+++ b/repo/plugin_video_mubi/resources/lib/filters.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+from typing import Any, Dict, List
+
 import xbmc
 import xbmcaddon
-from typing import List, Dict, Any
+
 
 class FilmFilter:
     """

--- a/repo/plugin_video_mubi/resources/lib/library.py
+++ b/repo/plugin_video_mubi/resources/lib/library.py
@@ -19,7 +19,7 @@ class Library:
     def add_film(self, film: Film):
         if not film or not film.mubi_id or not film.title or not film.metadata:
             raise ValueError("Invalid film: missing required fields (mubi_id, title, or metadata).")
-        
+
         if film.mubi_id in self.films:
             # Film exists, merge availability data
             existing_film = self.films[film.mubi_id]
@@ -44,11 +44,11 @@ class Library:
 
         # Log films that contain problematic characters for debugging
         for film in self.films.values():
-            if '#' in film.title or any(char in film.title for char in '<>:"/\\|?*^%$&{}@!;`~'):
+            if "#" in film.title or any(char in film.title for char in '<>:"/\\|?*^%$&{}@!;`~'):
                 xbmc.log(
                     f"Processing film with special characters: '{film.title}' "
                     f"-> sanitized: '{film.get_sanitized_folder_name()}'",
-                    xbmc.LOGINFO
+                    xbmc.LOGINFO,
                 )
 
         # Initialize counters
@@ -68,28 +68,33 @@ class Library:
         # Get concurrency setting (default to 5 for safety on low-end devices)
         # 1 = Serial, 5 = Standard, 10+ = High Performance
         try:
-             max_workers = xbmcaddon.Addon().getSettingInt("sync_concurrency")
-             
-             if max_workers == 0:
-                 # Auto mode: 90% of threads
-                 cpu_count = os.cpu_count() or 1
-                 max_workers = max(1, int(cpu_count * 0.9))
-                 xbmc.log(f"MUBI Sync: Auto-concurrency detected {cpu_count} CPUs. Using {max_workers} threads (90%).", xbmc.LOGINFO)
-             elif max_workers < 1:
-                 # Fallback for invalid negative values
-                 max_workers = 5
+            max_workers = xbmcaddon.Addon().getSettingInt("sync_concurrency")
+
+            if max_workers == 0:
+                # Auto mode: 90% of threads
+                cpu_count = os.cpu_count() or 1
+                max_workers = max(1, int(cpu_count * 0.9))
+                xbmc.log(
+                    f"MUBI Sync: Auto-concurrency detected {cpu_count} CPUs. Using {max_workers} threads (90%).",
+                    xbmc.LOGINFO,
+                )
+            elif max_workers < 1:
+                # Fallback for invalid negative values
+                max_workers = 5
         except Exception:
-             max_workers = 5
-             
+            max_workers = 5
+
         xbmc.log(f"Starting sync with {max_workers} worker threads.", xbmc.LOGDEBUG)
-        
+
         processed_count = 0
 
         try:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 # Submit all tasks
                 future_to_film = {
-                    executor.submit(self.prepare_files_for_film, film, base_url, plugin_userdata_path, skip_external_metadata): film
+                    executor.submit(
+                        self.prepare_files_for_film, film, base_url, plugin_userdata_path, skip_external_metadata
+                    ): film
                     for film in self.films.values()
                     if self.is_film_valid(film)
                 }
@@ -108,7 +113,7 @@ class Library:
 
                     film = future_to_film[future]
                     processed_count += 1
-                    
+
                     # Update progress
                     percent = int((processed_count / films_to_process) * 100)
                     progress_msg = f"Processing movie {processed_count} of {films_to_process}:\n{film.title}"
@@ -146,11 +151,11 @@ class Library:
                 f"Failed to add: {failed_to_add}\n"
                 f"Obsolete movies removed: {obsolete_films_count}"
             )
-            
+
             # Trigger individual updates for modified ratings
             if films_to_kodi_update:
                 xbmc.log(f"Triggering metadata refresh for {len(films_to_kodi_update)} films...", xbmc.LOGINFO)
-                
+
                 # OPTIMIZATION: Fetch all Mubi movies in one go to avoid N RPC calls
                 movie_lookup = {}
                 try:
@@ -161,9 +166,9 @@ class Library:
                         "method": "VideoLibrary.GetMovies",
                         "params": {
                             "filter": {"field": "path", "operator": "contains", "value": folder_filter},
-                            "properties": ["file"]
+                            "properties": ["file"],
                         },
-                        "id": "mubi_lookup"
+                        "id": "mubi_lookup",
                     }
                     rpc_res = json.loads(xbmc.executeJSONRPC(json.dumps(rpc_query)))
                     if "result" in rpc_res and "movies" in rpc_res["result"]:
@@ -174,7 +179,7 @@ class Library:
 
                 refresh_count = 0
                 total_to_refresh = len(films_to_kodi_update)
-                
+
                 for strm_path in films_to_kodi_update:
                     refresh_count += 1
                     # Update progress UI for the refresh phase
@@ -182,37 +187,35 @@ class Library:
                         p_percent = int((refresh_count / total_to_refresh) * 100)
                         p_msg = f"Refreshing Kodi metadata ({refresh_count}/{total_to_refresh}):\n{strm_path.name}"
                         pDialog.update(p_percent, p_msg)
-                    
+
                     # Pass the pre-fetched movie_id if available
                     m_id = movie_lookup.get(str(strm_path))
                     self.refresh_film_metadata(strm_path, movie_id=m_id)
-            
+
             # Log results
             xbmc.log(
                 f"Sync completed. New: {newly_added}, Updated: {rating_updated}, Failed: {failed_to_add}, "
                 f"Obsolete removed: {obsolete_films_count}",
-                xbmc.LOGDEBUG
+                xbmc.LOGDEBUG,
             )
-            
+
             # Show summary dialog
             xbmcgui.Dialog().ok("MUBI", message)
         finally:
             # Ensure the dialog is closed in the end
             pDialog.close()
 
-
-
     def is_film_valid(self, film: Film) -> bool:
         # Check that film has all necessary attributes AND at least one available country
         if not film.mubi_id or not film.title or not film.metadata:
             return False
-            
+
         # Check integrity of available_countries
         # Case 1: Empty dictionary (True Zombie) - Caught by 'and film.available_countries'
         # Case 2: Keys with empty values (Semi-Zombie) - e.g. {'DK': {}} due to null consumable
         if not film.available_countries:
             return False
-            
+
         # Ensure film is actually playable based on date ranges
         return film.is_playable()
 
@@ -248,16 +251,16 @@ class Library:
                 # Check if rating needs update (only for GitHub sync/when we have Bayesian data)
                 # If rating is NOT synced, we shouldn't return None; we should proceed to overwrite NFO.
                 rating_synced = film.is_rating_synced(nfo_file)
-                
+
                 if rating_synced:
                     # Update country availability in NFO file (quick operation)
                     xbmc.log(f"Updating availability for '{film.title}' (NFO exists & rating synced).", xbmc.LOGDEBUG)
                     film.update_nfo_availability(nfo_file)
                     return None  # Indicate availability was updated (not a new film)
                 else:
-                     xbmc.log(f"Forcing NFO update for '{film.title}' due to rating change.", xbmc.LOGINFO)
-                     # Fall through to create_nfo_file which overwrites
-                     # We will return special status later if successful
+                    xbmc.log(f"Forcing NFO update for '{film.title}' due to rating change.", xbmc.LOGINFO)
+                    # Fall through to create_nfo_file which overwrites
+                    # We will return special status later if successful
         except PermissionError as e:
             xbmc.log(f"PermissionError when accessing files for film '{film.title}': {e}", xbmc.LOGERROR)
             return False  # Indicate failure due to permission error
@@ -274,8 +277,7 @@ class Library:
             # Verify if the NFO file was created successfully
             if not nfo_file.exists():
                 xbmc.log(
-                    f"Skipping creation of STRM file for '{film.title}' as NFO file was not created.",
-                    xbmc.LOGWARNING
+                    f"Skipping creation of STRM file for '{film.title}' as NFO file was not created.", xbmc.LOGWARNING
                 )
                 # Remove the movie folder since NFO creation failed
                 shutil.rmtree(film_path)
@@ -289,8 +291,7 @@ class Library:
             # BUG #9 FIX: Verify that the STRM file was actually created
             if not strm_file.exists():
                 xbmc.log(
-                    f"STRM file creation failed for '{film.title}' - file does not exist after creation.",
-                    xbmc.LOGERROR
+                    f"STRM file creation failed for '{film.title}' - file does not exist after creation.", xbmc.LOGERROR
                 )
                 # Remove the movie folder since STRM creation failed
                 shutil.rmtree(film_path)
@@ -299,7 +300,7 @@ class Library:
 
             xbmc.log(f"Successfully created STRM file for '{film.title}'.", xbmc.LOGDEBUG)
             xbmc.log(f"Successfully created STRM file for '{film.title}'.", xbmc.LOGDEBUG)
-            
+
             if nfo_exists:
                 return "RATING_UPDATED"
             return True  # Indicate successful creation of both files
@@ -313,18 +314,17 @@ class Library:
                 xbmc.log(f"Removed folder '{film_path}' due to error.", xbmc.LOGDEBUG)
             return False  # Indicate failure due to exception
 
-
-
-
     def remove_obsolete_files(self, plugin_userdata_path: Path) -> int:
         """
         Remove folders in plugin_userdata_path that do not correspond to any film in the library.
-        
+
         :param plugin_userdata_path: Path where the film folders are stored.
         :return: The number of obsolete film folders removed.
         """
         # Get a set of sanitized folder names for the current films in the library
-        current_film_folders = {film.get_sanitized_folder_name() for film in self.films.values() if self.is_film_valid(film)}
+        current_film_folders = {
+            film.get_sanitized_folder_name() for film in self.films.values() if self.is_film_valid(film)
+        }
 
         # Track obsolete folder count
         obsolete_folders_count = 0
@@ -342,51 +342,51 @@ class Library:
         """
         Force a metadata refresh for a specific film using JSON-RPC.
         This is more reliable than UpdateLibrary for existing items where only metadata changed.
-        
+
         :param strm_path: Absolute path to the .strm file of the film.
         :param movie_id: Optional pre-fetched Kodi movieid.
         """
         try:
             # 1. Use provided movie_id or find it using VideoLibrary.GetMovies
             path_str = str(strm_path)
-            
+
             if not movie_id:
                 # Construct JSON-RPC request to find the movie
                 # We filter by 'file' to find the specific item
                 find_req = {
-                    "jsonrpc": "2.0", 
-                    "method": "VideoLibrary.GetMovies", 
+                    "jsonrpc": "2.0",
+                    "method": "VideoLibrary.GetMovies",
                     "params": {
                         "filter": {"field": "file", "operator": "is", "value": path_str},
-                        "properties": ["title"] 
-                    }, 
-                    "id": 1
+                        "properties": ["title"],
+                    },
+                    "id": 1,
                 }
-                
+
                 find_resp_str = xbmc.executeJSONRPC(json.dumps(find_req))
                 find_resp = json.loads(find_resp_str)
-                
+
                 if "result" in find_resp and "movies" in find_resp["result"]:
                     movies = find_resp["result"]["movies"]
                     if movies:
                         movie_id = movies[0].get("movieid")
-                
+
                 # 2. Fallback: Search by filename if exact path match failed
                 if not movie_id:
                     xbmc.log(f"Exact path match failed for '{path_str}', trying filename match...", xbmc.LOGDEBUG)
                     filename = strm_path.name
                     find_req_fallback = {
-                        "jsonrpc": "2.0", 
-                        "method": "VideoLibrary.GetMovies", 
+                        "jsonrpc": "2.0",
+                        "method": "VideoLibrary.GetMovies",
                         "params": {
                             "filter": {"field": "filename", "operator": "is", "value": filename},
-                            "properties": ["title", "file"] 
-                        }, 
-                        "id": 2
+                            "properties": ["title", "file"],
+                        },
+                        "id": 2,
                     }
                     find_resp_str_fallback = xbmc.executeJSONRPC(json.dumps(find_req_fallback))
                     find_resp_fallback = json.loads(find_resp_str_fallback)
-                    
+
                     if "result" in find_resp_fallback and "movies" in find_resp_fallback["result"]:
                         movies = find_resp_fallback["result"]["movies"]
                         if movies:
@@ -395,17 +395,14 @@ class Library:
 
             if movie_id:
                 xbmc.log(f"Found movieid {movie_id} for '{path_str}'. Refreshing...", xbmc.LOGDEBUG)
-                
+
                 # 3. Refresh the specific movie using VideoLibrary.RefreshMovie
                 # ignorenfo=false is default, so it will read our newly updated NFO
                 refresh_req = {
                     "jsonrpc": "2.0",
                     "method": "VideoLibrary.RefreshMovie",
-                    "params": {
-                        "movieid": movie_id,
-                        "ignorenfo": False 
-                    },
-                    "id": 1
+                    "params": {"movieid": movie_id, "ignorenfo": False},
+                    "id": 1,
                 }
                 xbmc.executeJSONRPC(json.dumps(refresh_req))
                 xbmc.log(f"Triggered RefreshMovie for movieid {movie_id}", xbmc.LOGINFO)
@@ -413,8 +410,7 @@ class Library:
                 xbmc.log(f"Could not find movieid for '{path_str}'. Fallback to UpdateLibrary scan.", xbmc.LOGWARNING)
                 # Fallback: scan the parent folder
                 parent_dir = strm_path.parent
-                xbmc.executebuiltin(f'UpdateLibrary(video, {parent_dir})')
+                xbmc.executebuiltin(f"UpdateLibrary(video, {parent_dir})")
 
         except Exception as e:
             xbmc.log(f"Error refreshing metadata for '{strm_path}': {e}", xbmc.LOGERROR)
-

--- a/repo/plugin_video_mubi/resources/lib/library.py
+++ b/repo/plugin_video_mubi/resources/lib/library.py
@@ -1,15 +1,16 @@
-from pathlib import Path
-import sys
-import xbmc
-import xbmcgui
-import xbmcaddon
-from .film import Film
-from typing import List, Optional, Tuple, Union
+import json
 import os
 import shutil
-from typing import Set
-import re
-import json
+import sys
+from pathlib import Path
+from typing import Optional, Union
+
+import xbmc
+import xbmcaddon
+import xbmcgui
+
+from .film import Film
+
 
 class Library:
     def __init__(self):
@@ -67,7 +68,6 @@ class Library:
         # Get concurrency setting (default to 5 for safety on low-end devices)
         # 1 = Serial, 5 = Standard, 10+ = High Performance
         try:
-             import xbmcaddon
              max_workers = xbmcaddon.Addon().getSettingInt("sync_concurrency")
              
              if max_workers == 0:

--- a/repo/plugin_video_mubi/resources/lib/local_server.py
+++ b/repo/plugin_video_mubi/resources/lib/local_server.py
@@ -1,9 +1,10 @@
-import threading
-import socket
 import os
-import xbmcvfs
+import threading
 from http.server import SimpleHTTPRequestHandler
 from socketserver import ThreadingTCPServer
+
+import xbmcvfs
+
 
 class LocalServer:
     """
@@ -76,7 +77,7 @@ class LocalServer:
             # Quick timeout test - just check if server responds
             test_url = f"http://127.0.0.1:{self.port}/"
             req = urllib.request.Request(test_url, method='HEAD')
-            with urllib.request.urlopen(req, timeout=2) as response:
+            with urllib.request.urlopen(req, timeout=2):
                 # Any response (even 404) means server is working
                 return True
         except Exception:

--- a/repo/plugin_video_mubi/resources/lib/local_server.py
+++ b/repo/plugin_video_mubi/resources/lib/local_server.py
@@ -11,6 +11,7 @@ class LocalServer:
     A simple threaded HTTP server to serve files from Kodi's temp directory.
     This bypasses inputstream.adaptive's inability to read local files on some platforms.
     """
+
     _instance = None
     _lock = threading.Lock()
 
@@ -43,9 +44,9 @@ class LocalServer:
                     pass
 
             # Create server on ephemeral port
-            self.server = ThreadingTCPServer(('127.0.0.1', 0), Handler)
+            self.server = ThreadingTCPServer(("127.0.0.1", 0), Handler)
             self.port = self.server.server_address[1]
-            
+
             self.thread = threading.Thread(target=self.server.serve_forever)
             self.thread.daemon = True
             self.thread.start()
@@ -56,7 +57,7 @@ class LocalServer:
         Use special://temp/filename or absolute path.
         """
         self.start()
-        
+
         # We only serve from temp dir, so extract filename
         filename = os.path.basename(file_path)
         return f"http://127.0.0.1:{self.port}/{filename}"
@@ -65,18 +66,19 @@ class LocalServer:
         """
         Tests if the LocalServer is working by making a quick HTTP request.
         Returns True if server responds, False otherwise.
-        
+
         This catches issues like Linux ABI mismatches that cause crashes
         when switching between localhost and remote CDN contexts.
         """
         if not self.server:
             return False
-        
+
         try:
             import urllib.request
+
             # Quick timeout test - just check if server responds
             test_url = f"http://127.0.0.1:{self.port}/"
-            req = urllib.request.Request(test_url, method='HEAD')
+            req = urllib.request.Request(test_url, method="HEAD")
             with urllib.request.urlopen(req, timeout=2):
                 # Any response (even 404) means server is working
                 return True

--- a/repo/plugin_video_mubi/resources/lib/metadata.py
+++ b/repo/plugin_video_mubi/resources/lib/metadata.py
@@ -31,7 +31,7 @@ class Metadata:
         tagline: Optional[str] = "",
         audio_channels: Optional[List[str]] = None,
         bayesian_rating: Optional[float] = None,
-        bayesian_votes: Optional[int] = None
+        bayesian_votes: Optional[int] = None,
     ):
         try:
             self.title = title
@@ -77,34 +77,33 @@ class Metadata:
         """
         try:
             return {
-                'title': self.title,
-                'director': self.director,
-                'year': self.year,
-                'duration': self.duration,
-                'country': self.country,
-                'plot': self.plot,
-                'plotoutline': self.plotoutline,
-                'genre': self.genre,
-                'originaltitle': self.originaltitle,
-                'rating': self.rating,
-                'votes': self.votes,
-                'castandrole': self.castandrole,
-                'dateadded': self.dateadded,
-                'trailer': self.trailer,
-                'image': self.image,
-                'mpaa': self.mpaa,
-                'artwork_urls': self.artwork_urls,
-                'audio_languages': self.audio_languages,
-                'subtitle_languages': self.subtitle_languages,
-                'media_features': self.media_features,
-                'premiered': self.premiered,
-                'content_warnings': self.content_warnings,
-                'tagline': self.tagline,
-                'audio_channels': self.audio_channels,
-                'bayesian_rating': self.bayesian_rating,
-                'bayesian_votes': self.bayesian_votes
+                "title": self.title,
+                "director": self.director,
+                "year": self.year,
+                "duration": self.duration,
+                "country": self.country,
+                "plot": self.plot,
+                "plotoutline": self.plotoutline,
+                "genre": self.genre,
+                "originaltitle": self.originaltitle,
+                "rating": self.rating,
+                "votes": self.votes,
+                "castandrole": self.castandrole,
+                "dateadded": self.dateadded,
+                "trailer": self.trailer,
+                "image": self.image,
+                "mpaa": self.mpaa,
+                "artwork_urls": self.artwork_urls,
+                "audio_languages": self.audio_languages,
+                "subtitle_languages": self.subtitle_languages,
+                "media_features": self.media_features,
+                "premiered": self.premiered,
+                "content_warnings": self.content_warnings,
+                "tagline": self.tagline,
+                "audio_channels": self.audio_channels,
+                "bayesian_rating": self.bayesian_rating,
+                "bayesian_votes": self.bayesian_votes,
             }
         except Exception as e:
             xbmc.log(f"Error converting Metadata to dict: {e}", xbmc.LOGERROR)
             return {}
-

--- a/repo/plugin_video_mubi/resources/lib/metadata.py
+++ b/repo/plugin_video_mubi/resources/lib/metadata.py
@@ -1,5 +1,6 @@
-import xbmc
 from typing import List, Optional
+
+import xbmc
 
 
 class Metadata:

--- a/repo/plugin_video_mubi/resources/lib/migrations.py
+++ b/repo/plugin_video_mubi/resources/lib/migrations.py
@@ -1,8 +1,10 @@
 # resources/lib/utils.py
 import xml.etree.ElementTree as ET
+
 import xbmc
-import xbmcvfs
 import xbmcgui
+import xbmcvfs
+
 
 def add_mubi_source():
     sources_file = xbmcvfs.translatePath('special://profile/sources.xml')

--- a/repo/plugin_video_mubi/resources/lib/migrations.py
+++ b/repo/plugin_video_mubi/resources/lib/migrations.py
@@ -7,9 +7,9 @@ import xbmcvfs
 
 
 def add_mubi_source():
-    sources_file = xbmcvfs.translatePath('special://profile/sources.xml')
+    sources_file = xbmcvfs.translatePath("special://profile/sources.xml")
     mubi_source_name = "MUBI Movies"
-    mubi_path = 'special://userdata/addon_data/plugin.video.mubi'
+    mubi_path = "special://userdata/addon_data/plugin.video.mubi"
 
     try:
         # Check if the sources.xml file exists
@@ -64,10 +64,11 @@ def add_mubi_source():
     except Exception as e:
         xbmc.log(f"An error occurred in add_mubi_source: {e}", level=xbmc.LOGERROR)
 
+
 def read_xml(file_path):
     try:
         if xbmcvfs.exists(file_path):
-            with xbmcvfs.File(file_path, 'r') as f:
+            with xbmcvfs.File(file_path, "r") as f:
                 content = f.read()
             tree = ET.ElementTree(ET.fromstring(content))
             xbmc.log(f"Successfully read XML file: {file_path}", level=xbmc.LOGDEBUG)
@@ -79,10 +80,11 @@ def read_xml(file_path):
         xbmc.log(f"Error reading XML file {file_path}: {e}", level=xbmc.LOGERROR)
         return None
 
+
 def write_xml(tree, file_path):
     try:
-        content = ET.tostring(tree.getroot(), encoding='unicode', method='xml')
-        with xbmcvfs.File(file_path, 'w') as f:
+        content = ET.tostring(tree.getroot(), encoding="unicode", method="xml")
+        with xbmcvfs.File(file_path, "w") as f:
             f.write(content)
         xbmc.log(f"Successfully wrote XML file: {file_path}", level=xbmc.LOGDEBUG)
     except Exception as e:
@@ -99,13 +101,15 @@ def show_source_added_message():
     )
     dialog.ok("MUBI Source Added", message)
 
+
 def is_first_run(plugin):
     # Check if the addon is running for the first time by checking a setting
-    return not plugin.getSettingBool('first_run_completed')
+    return not plugin.getSettingBool("first_run_completed")
+
 
 def mark_first_run(plugin):
     # Mark that the first run has been completed
-    plugin.setSettingBool('first_run_completed', True)
+    plugin.setSettingBool("first_run_completed", True)
 
 
 def migrate_to_fast_sync(plugin):
@@ -122,12 +126,12 @@ def migrate_to_fast_sync(plugin):
     because True is also a legitimate user choice. After the migration the user
     remains free to toggle enable_fast_sync back off; we never force it again.
     """
-    if plugin.getSettingBool('fast_sync_migration_done'):
+    if plugin.getSettingBool("fast_sync_migration_done"):
         # Already migrated - respect whatever the user has set since.
         return False
 
-    plugin.setSettingBool('enable_fast_sync', True)
-    plugin.setSettingBool('fast_sync_migration_done', True)
+    plugin.setSettingBool("enable_fast_sync", True)
+    plugin.setSettingBool("fast_sync_migration_done", True)
     xbmc.log("Migrated user to fast sync (one-time)", level=xbmc.LOGINFO)
     return True
 
@@ -142,7 +146,7 @@ def migrate_genre_settings(plugin):
     This runs only if the old skip_genres setting has a value.
     After migration, the old setting is cleared to prevent re-running.
     """
-    old_setting = plugin.getSetting('skip_genres')
+    old_setting = plugin.getSetting("skip_genres")
 
     if not old_setting or not old_setting.strip():
         # No migration needed - old setting is empty or doesn't exist
@@ -152,30 +156,30 @@ def migrate_genre_settings(plugin):
 
     # Mapping from genre names to new setting IDs
     genre_mapping = {
-        'action': 'skip_genre_action',
-        'adventure': 'skip_genre_adventure',
-        'animation': 'skip_genre_animation',
-        'avant-garde': 'skip_genre_avant_garde',
-        'comedy': 'skip_genre_comedy',
-        'commercial': 'skip_genre_commercial',
-        'crime': 'skip_genre_crime',
-        'cult': 'skip_genre_cult',
-        'documentary': 'skip_genre_documentary',
-        'drama': 'skip_genre_drama',
-        'erotica': 'skip_genre_erotica',
-        'fantasy': 'skip_genre_fantasy',
-        'horror': 'skip_genre_horror',
-        'lgbtq+': 'skip_genre_lgbtq',
-        'mystery': 'skip_genre_mystery',
-        'romance': 'skip_genre_romance',
-        'sci-fi': 'skip_genre_sci_fi',
-        'short': 'skip_genre_short',
-        'thriller': 'skip_genre_thriller',
-        'tv movie': 'skip_genre_tv_movie',
+        "action": "skip_genre_action",
+        "adventure": "skip_genre_adventure",
+        "animation": "skip_genre_animation",
+        "avant-garde": "skip_genre_avant_garde",
+        "comedy": "skip_genre_comedy",
+        "commercial": "skip_genre_commercial",
+        "crime": "skip_genre_crime",
+        "cult": "skip_genre_cult",
+        "documentary": "skip_genre_documentary",
+        "drama": "skip_genre_drama",
+        "erotica": "skip_genre_erotica",
+        "fantasy": "skip_genre_fantasy",
+        "horror": "skip_genre_horror",
+        "lgbtq+": "skip_genre_lgbtq",
+        "mystery": "skip_genre_mystery",
+        "romance": "skip_genre_romance",
+        "sci-fi": "skip_genre_sci_fi",
+        "short": "skip_genre_short",
+        "thriller": "skip_genre_thriller",
+        "tv movie": "skip_genre_tv_movie",
     }
 
     # Parse the old comma-separated list
-    genres_to_skip = [g.strip().lower() for g in old_setting.split(',')]
+    genres_to_skip = [g.strip().lower() for g in old_setting.split(",")]
     migrated_count = 0
 
     for genre in genres_to_skip:
@@ -188,7 +192,7 @@ def migrate_genre_settings(plugin):
             xbmc.log(f"Unknown genre '{genre}' - skipping migration", level=xbmc.LOGWARNING)
 
     # Clear the old setting to prevent re-running migration
-    plugin.setSetting('skip_genres', '')
+    plugin.setSetting("skip_genres", "")
 
     xbmc.log(f"Genre settings migration complete: {migrated_count} genres migrated", level=xbmc.LOGINFO)
     return True

--- a/repo/plugin_video_mubi/resources/lib/models.py
+++ b/repo/plugin_video_mubi/resources/lib/models.py
@@ -6,8 +6,10 @@ from pydantic import BaseModel
 # Nested Models for Film Data
 # ─────────────────────────────────────────────
 
+
 class ContentRating(BaseModel):
     """Content/age rating information."""
+
     label: Optional[str] = None
     rating_code: Optional[str] = None
     description: Optional[str] = None
@@ -16,6 +18,7 @@ class ContentRating(BaseModel):
 
 class ContentWarning(BaseModel):
     """Content warning tag."""
+
     id: int
     name: str
     key: str
@@ -23,6 +26,7 @@ class ContentWarning(BaseModel):
 
 class Stills(BaseModel):
     """Still image URLs at various sizes."""
+
     small: Optional[str] = None
     medium: Optional[str] = None
     standard: Optional[str] = None
@@ -34,6 +38,7 @@ class Stills(BaseModel):
 
 class Artwork(BaseModel):
     """Artwork asset with format and URL."""
+
     format: str
     locale: Optional[str] = None
     image_url: str
@@ -41,12 +46,14 @@ class Artwork(BaseModel):
 
 class MediaOptions(BaseModel):
     """Media playback options."""
+
     duration: Optional[int] = None
     hd: Optional[bool] = None
 
 
 class PlaybackLanguages(BaseModel):
     """Audio and subtitle language options."""
+
     audio_options: List[str] = []
     extended_audio_options: List[str] = []
     subtitle_options: List[str] = []
@@ -54,10 +61,9 @@ class PlaybackLanguages(BaseModel):
     media_features: List[str] = []
 
 
-
 class Consumable(BaseModel):
     """Film availability and playback information (per-country).
-    
+
     Note: The following fields were pruned from the JSON to reduce file size:
     - offered: Always [{"type": "catalogue", ...}]
     - film_id: Already at top level
@@ -65,15 +71,17 @@ class Consumable(BaseModel):
     - exclusive: Always false, not used
     - permit_download: Always true, not used
     """
+
     available_at: Optional[str] = None
     availability: Optional[str] = None
     availability_ends_at: Optional[str] = None
     expires_at: Optional[str] = None
     # Playback languages moved to global Film scope
-    
-    
+
+
 class Award(BaseModel):
     """Award information."""
+
     name: Optional[str] = None
     category: Optional[str] = None
     year: Optional[int] = None
@@ -81,6 +89,7 @@ class Award(BaseModel):
 
 class Rating(BaseModel):
     """Multi-source rating entry."""
+
     source: str
     score_over_10: float
     voters: int
@@ -90,20 +99,22 @@ class Rating(BaseModel):
 # Main Film Model
 # ─────────────────────────────────────────────
 
+
 class Film(BaseModel):
     """
     Complete film data model matching the extended Mubi API schema.
     Used for both films.json and series.json entries.
     """
+
     # Core identifiers
     mubi_id: int
     tmdb_id: Optional[int] = None
     imdb_id: Optional[str] = None
-    
+
     # Extended metadata
     mpaa: Optional[Dict[str, Optional[str]]] = None
     imdb_id: Optional[str] = None
-    
+
     # Basic metadata
     title: str
     original_title: Optional[str] = None
@@ -114,29 +125,29 @@ class Film(BaseModel):
     short_synopsis: Optional[str] = None
     default_editorial: Optional[str] = None
     historic_countries: List[str] = []
-    
+
     # Mubi-specific ratings
     popularity: Optional[int] = None
     average_rating_out_of_ten: Optional[float] = None
     number_of_ratings: Optional[int] = None
     hd: Optional[bool] = None
     critic_review_rating: Optional[float] = None
-    
+
     # Content rating & warnings
     content_rating: Optional[ContentRating] = None
     content_warnings: List[ContentWarning] = []
-    
+
     # Imagery & artwork
     stills: Optional[Stills] = None
     still_url: Optional[str] = None
     portrait_image: Optional[str] = None
     artworks: List[Artwork] = []
-    
+
     # Trailers
     trailer_url: Optional[str] = None
     trailer_id: Optional[int] = None
     optimised_trailers: Optional[List[Dict[str, Any]]] = None
-    
+
     # Availability & playback
     # Consumable info is now per-country in available_countries
     playback_languages: Optional[PlaybackLanguages] = None
@@ -144,30 +155,31 @@ class Film(BaseModel):
     # Awards & press
     award: Optional[Award] = None
     press_quote: Optional[Any] = None  # Can be str or dict
-    
+
     # Series/episode info (null for regular films)
     episode: Optional[Dict[str, Any]] = None
     series: Optional[Dict[str, Any]] = None
-    
+
     # Scraper-added metadata
     available_countries: Dict[str, Consumable] = {}
-    
+
     # Multi-source ratings (enriched)
     ratings: List[Rating] = []
 
     # Bayesian Calcuations
 
-    
     class Config:
-        extra = 'ignore'  # Allow extra fields for API compatibility
+        extra = "ignore"  # Allow extra fields for API compatibility
 
 
 # ─────────────────────────────────────────────
 # Database Wrapper Models
 # ─────────────────────────────────────────────
 
+
 class Meta(BaseModel):
     """Metadata about the generated JSON file."""
+
     generated_at: str
     version: int
     version_label: Optional[str] = None  # Human-readable version (e.g., "1.0-beta.1")
@@ -177,12 +189,14 @@ class Meta(BaseModel):
 
 class BayesStats(BaseModel):
     """Bayesian Rating Calibration Constants."""
+
     global_mean_C: float
     mubi_confidence_m: float
 
 
 class MubiDatabase(BaseModel):
     """Root model for films.json and series.json files."""
+
     meta: Meta
     bayes_stats: Optional[BayesStats] = None
     items: List[Film]

--- a/repo/plugin_video_mubi/resources/lib/models.py
+++ b/repo/plugin_video_mubi/resources/lib/models.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Any, Dict
-from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Optional
 
+from pydantic import BaseModel
 
 # ─────────────────────────────────────────────
 # Nested Models for Film Data

--- a/repo/plugin_video_mubi/resources/lib/mpd_patcher.py
+++ b/repo/plugin_video_mubi/resources/lib/mpd_patcher.py
@@ -13,175 +13,187 @@ class MPDPatcher:
     Specifically, it injects explicit Labels for audio streams based on their channel configuration,
     allowing Kodi to correctly prioritize Stereo vs Surround tracks based on system settings.
     """
-    
+
     def __init__(self):
         self.temp_dir = tempfile.gettempdir()
 
     def patch(self, stream_url, headers):
         """
         Downloads, patches, and saves the MPD manifest.
-        
+
         :param stream_url: The original secure URL of the MPD manifest.
         :param headers: Dictionary of headers to use for the request.
         :return: Path to the local patched MPD file, or None if patching failed.
         """
         try:
             xbmc.log(f"MPDPatcher: Downloading manifest from {stream_url}", xbmc.LOGDEBUG)
-            
+
             # Download manifest
             response = requests.get(stream_url, headers=headers, timeout=10)
             if response.status_code != 200:
                 xbmc.log(f"MPDPatcher: Failed to download manifest (Status: {response.status_code})", xbmc.LOGERROR)
                 return None
-            
+
             manifest_content = response.text
-            
+
             # Parse XML
             # Register namespaces to prevent 'ns0' prefixes
-            ET.register_namespace('', "urn:mpeg:dash:schema:mpd:2011")
+            ET.register_namespace("", "urn:mpeg:dash:schema:mpd:2011")
             # Some MPDs might use other namespaces, but this is the standard one
-            
+
             try:
                 root = ET.fromstring(manifest_content)
             except ET.ParseError as e:
                 xbmc.log(f"MPDPatcher: Failed to parse XML: {e}", xbmc.LOGERROR)
                 return None
-            
+
             patched = False
-            
+
             # Iterate through AdaptationSets
             # Namespace handling in ElementTree is verbose, so we use logic to handle it
-            
-            for adaptation_set in root.iter('{urn:mpeg:dash:schema:mpd:2011}AdaptationSet'):
-                mime_type = adaptation_set.get('mimeType')
-                adaptation_id = adaptation_set.get('id', 'unknown')
+
+            for adaptation_set in root.iter("{urn:mpeg:dash:schema:mpd:2011}AdaptationSet"):
+                mime_type = adaptation_set.get("mimeType")
+                adaptation_id = adaptation_set.get("id", "unknown")
                 xbmc.log(f"MPDPatcher: Inspecting AdaptationSet {adaptation_id} (mime: {mime_type})", xbmc.LOGINFO)
-                
-                if mime_type == 'audio/mp4':
+
+                if mime_type == "audio/mp4":
                     # Look for AudioChannelConfiguration
                     # Standard scheme for channel config
                     acc_scheme = "urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
-                    
+
                     channel_count = None
-                    
+
                     # Log children tags for debugging
                     child_tags = [child.tag for child in adaptation_set]
                     xbmc.log(f"MPDPatcher: Children: {child_tags}", xbmc.LOGINFO)
                     acc_scheme = "urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
-                    
+
                     channel_count = None
-                    
+
                     # Find the AudioChannelConfiguration node
                     for child in adaptation_set:
                         tag_name = child.tag
-                        if 'AudioChannelConfiguration' in tag_name:
-                             local_scheme = child.get('schemeIdUri')
-                             local_value = child.get('value')
-                             xbmc.log(f"MPDPatcher: Found ACC node. Scheme: {local_scheme}, Value: {local_value}", xbmc.LOGINFO)
-                             
-                             # Standard MPEG-DASH scheme
-                             if local_scheme == acc_scheme:
+                        if "AudioChannelConfiguration" in tag_name:
+                            local_scheme = child.get("schemeIdUri")
+                            local_value = child.get("value")
+                            xbmc.log(
+                                f"MPDPatcher: Found ACC node. Scheme: {local_scheme}, Value: {local_value}",
+                                xbmc.LOGINFO,
+                            )
+
+                            # Standard MPEG-DASH scheme
+                            if local_scheme == acc_scheme:
                                 channel_count = local_value
                                 break
-                             # Dolby scheme
-                             elif local_scheme == "tag:dolby.com,2014:dash:audio_channel_configuration:2011":
-                                 # F801 (hex) is the standard Dolby bitmask for 5.1 (L, C, R, Ls, Rs, LFE)
-                                 # We can map this specific value to 6 channels
-                                 if local_value and local_value.lower() == 'f801':
-                                     xbmc.log("MPDPatcher: Detected Dolby 5.1 channel mask (F801)", xbmc.LOGINFO)
-                                     channel_count = "6"
-                                     break
-                                 else:
-                                     xbmc.log(f"MPDPatcher: Unknown Dolby channel mask: {local_value}", xbmc.LOGWARNING)
-                             else:
+                            # Dolby scheme
+                            elif local_scheme == "tag:dolby.com,2014:dash:audio_channel_configuration:2011":
+                                # F801 (hex) is the standard Dolby bitmask for 5.1 (L, C, R, Ls, Rs, LFE)
+                                # We can map this specific value to 6 channels
+                                if local_value and local_value.lower() == "f801":
+                                    xbmc.log("MPDPatcher: Detected Dolby 5.1 channel mask (F801)", xbmc.LOGINFO)
+                                    channel_count = "6"
+                                    break
+                                else:
+                                    xbmc.log(f"MPDPatcher: Unknown Dolby channel mask: {local_value}", xbmc.LOGWARNING)
+                            else:
                                 xbmc.log(f"MPDPatcher: Scheme mismatch! Expected: {acc_scheme}", xbmc.LOGINFO)
-                    
+
                     if channel_count:
                         # Create Label if missing
                         label_node = None
                         for child in adaptation_set:
-                            if 'Label' in child.tag:
+                            if "Label" in child.tag:
                                 label_node = child
                                 break
-                        
+
                         if label_node is None:
-                            label_node = ET.Element('{urn:mpeg:dash:schema:mpd:2011}Label')
+                            label_node = ET.Element("{urn:mpeg:dash:schema:mpd:2011}Label")
                             adaptation_set.insert(0, label_node)
-                        
+
                         # Add Role element to guide default selection
                         # We want Stereo (2.0) to be MAIN, and Surround (5.1) to be ALTERNATE
                         # This helps Kodi select Stereo by default if user preferences are standard
-                        
+
                         role_node = None
                         for child in adaptation_set:
-                            if 'Role' in child.tag and child.get('schemeIdUri') == "urn:mpeg:dash:role:2011":
+                            if "Role" in child.tag and child.get("schemeIdUri") == "urn:mpeg:dash:role:2011":
                                 role_node = child
                                 break
-                        
+
                         if role_node is None:
-                            role_node = ET.Element('{urn:mpeg:dash:schema:mpd:2011}Role')
-                            role_node.set('schemeIdUri', "urn:mpeg:dash:role:2011")
+                            role_node = ET.Element("{urn:mpeg:dash:schema:mpd:2011}Role")
+                            role_node.set("schemeIdUri", "urn:mpeg:dash:role:2011")
                             adaptation_set.insert(0, role_node)
 
-                        lang = adaptation_set.get('lang', 'en')
-                        
+                        lang = adaptation_set.get("lang", "en")
+
                         if str(channel_count) == "2":
                             label_node.text = "Stereo (2.0)"
-                            role_node.set('value', 'main')
-                            xbmc.log(f"MPDPatcher: Added Label 'Stereo (2.0)' and Role 'main' to audio track ({lang})", xbmc.LOGDEBUG)
-                            patched = True # Mark as patched if we modified
+                            role_node.set("value", "main")
+                            xbmc.log(
+                                f"MPDPatcher: Added Label 'Stereo (2.0)' and Role 'main' to audio track ({lang})",
+                                xbmc.LOGDEBUG,
+                            )
+                            patched = True  # Mark as patched if we modified
                         elif str(channel_count) == "6":
                             label_node.text = "Surround (5.1)"
-                            role_node.set('value', 'alternate')
-                            xbmc.log(f"MPDPatcher: Added Label 'Surround (5.1)' and Role 'alternate' to audio track ({lang})", xbmc.LOGDEBUG)
-                            patched = True # Mark as patched if we modified
+                            role_node.set("value", "alternate")
+                            xbmc.log(
+                                f"MPDPatcher: Added Label 'Surround (5.1)' and Role 'alternate' to audio track ({lang})",
+                                xbmc.LOGDEBUG,
+                            )
+                            patched = True  # Mark as patched if we modified
                         else:
                             label_node.text = f"Audio ({channel_count}ch)"
                             # For other channel counts, we don't assign a specific role
-                            xbmc.log(f"MPDPatcher: Added Label 'Audio ({channel_count}ch)' to audio track ({lang})", xbmc.LOGDEBUG)
-                            patched = True # Mark as patched if we modified
+                            xbmc.log(
+                                f"MPDPatcher: Added Label 'Audio ({channel_count}ch)' to audio track ({lang})",
+                                xbmc.LOGDEBUG,
+                            )
+                            patched = True  # Mark as patched if we modified
                             # No 'else' for role_node.set('value') here, as we only set for 2 and 6.
 
             if patched:
                 # Ensure BaseURL is absolute
-                # If the manifest uses relative segments, we need an absolute BaseURL 
+                # If the manifest uses relative segments, we need an absolute BaseURL
                 # pointing to the original location so resolving continues to work from the local file
-                
+
                 # Check for existing BaseURL
-                base_url_node = root.find('{urn:mpeg:dash:schema:mpd:2011}BaseURL')
-                
+                base_url_node = root.find("{urn:mpeg:dash:schema:mpd:2011}BaseURL")
+
                 if base_url_node is None:
                     # Create BaseURL pointing to the directory of the stream_url
                     import os.path
-                    
+
                     # Logic to get base path from URL
                     # e.g. https://example.com/stream/manifest.mpd -> https://example.com/stream/
-                    base_path = stream_url.rsplit('/', 1)[0] + '/'
-                    
-                    new_base = ET.Element('{urn:mpeg:dash:schema:mpd:2011}BaseURL')
+                    base_path = stream_url.rsplit("/", 1)[0] + "/"
+
+                    new_base = ET.Element("{urn:mpeg:dash:schema:mpd:2011}BaseURL")
                     new_base.text = base_path
                     root.insert(0, new_base)
                     xbmc.log(f"MPDPatcher: Injected BaseURL: {base_path}", xbmc.LOGDEBUG)
-                
+
                 # Save to Kodi's temp directory
                 temp_dir = xbmcvfs.translatePath("special://temp/")
                 if not os.path.exists(temp_dir):
                     os.makedirs(temp_dir)
 
-                fd, abs_path = tempfile.mkstemp(suffix='.mpd', prefix='mubi_patched_', dir=temp_dir)
-                
+                fd, abs_path = tempfile.mkstemp(suffix=".mpd", prefix="mubi_patched_", dir=temp_dir)
+
                 # Write back
-                with os.fdopen(fd, 'wb') as f:
+                with os.fdopen(fd, "wb") as f:
                     tree = ET.ElementTree(root)
-                    tree.write(f, encoding='UTF-8', xml_declaration=True)
-                
+                    tree.write(f, encoding="UTF-8", xml_declaration=True)
+
                 # Convert absolute path back to special:// URI for Kodi
                 filename = os.path.basename(abs_path)
                 special_path = f"special://temp/{filename}"
-                
+
                 xbmc.log(f"MPDPatcher: Saved patched manifest to {special_path} ({abs_path})", xbmc.LOGINFO)
                 return special_path
-            
+
             else:
                 xbmc.log("MPDPatcher: No audio tracks found to patch. Returning original.", xbmc.LOGDEBUG)
                 return None

--- a/repo/plugin_video_mubi/resources/lib/mpd_patcher.py
+++ b/repo/plugin_video_mubi/resources/lib/mpd_patcher.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+import tempfile
+import xml.etree.ElementTree as ET
+
+import requests
 import xbmc
 import xbmcvfs
-import requests
-import xml.etree.ElementTree as ET
-import tempfile
-import os
-from urllib.parse import urlparse
+
 
 class MPDPatcher:
     """
@@ -51,7 +51,6 @@ class MPDPatcher:
             
             # Iterate through AdaptationSets
             # Namespace handling in ElementTree is verbose, so we use logic to handle it
-            ns = {'mpd': 'urn:mpeg:dash:schema:mpd:2011'}
             
             for adaptation_set in root.iter('{urn:mpeg:dash:schema:mpd:2011}AdaptationSet'):
                 mime_type = adaptation_set.get('mimeType')
@@ -64,7 +63,6 @@ class MPDPatcher:
                     acc_scheme = "urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
                     
                     channel_count = None
-                    acc_node = None
                     
                     # Log children tags for debugging
                     child_tags = [child.tag for child in adaptation_set]
@@ -72,7 +70,6 @@ class MPDPatcher:
                     acc_scheme = "urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
                     
                     channel_count = None
-                    acc_node = None
                     
                     # Find the AudioChannelConfiguration node
                     for child in adaptation_set:
@@ -84,7 +81,6 @@ class MPDPatcher:
                              
                              # Standard MPEG-DASH scheme
                              if local_scheme == acc_scheme:
-                                acc_node = child
                                 channel_count = local_value
                                 break
                              # Dolby scheme
@@ -93,7 +89,6 @@ class MPDPatcher:
                                  # We can map this specific value to 6 channels
                                  if local_value and local_value.lower() == 'f801':
                                      xbmc.log("MPDPatcher: Detected Dolby 5.1 channel mask (F801)", xbmc.LOGINFO)
-                                     acc_node = child
                                      channel_count = "6"
                                      break
                                  else:

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -30,15 +30,14 @@ from .playback import generate_drm_license_key
 
 
 class Mubi:
-
     # Country code to full name mapping for user-friendly messages
     COUNTRY_NAMES = {
-        'CH': 'Switzerland',
-        'DE': 'Germany',
-        'US': 'the United States',
-        'GB': 'the United Kingdom',
-        'FR': 'France',
-        'JP': 'Japan',
+        "CH": "Switzerland",
+        "DE": "Germany",
+        "US": "the United States",
+        "GB": "the United Kingdom",
+        "FR": "France",
+        "JP": "Japan",
     }
 
     def __init__(self, session_manager):
@@ -49,7 +48,7 @@ class Mubi:
         :type session_manager: SessionManager
         """
         self.apiURL = MUBI_API_URL
-        self.UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0'
+        self.UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0"
         self.session_manager = session_manager  # Use session manager for session-related data
         self.library = Library()  # Initialize the Library
 
@@ -65,9 +64,22 @@ class Mubi:
 
         # List of sensitive header patterns (case-insensitive)
         sensitive_patterns = [
-            'authorization', 'api-key', 'api_key', 'x-api-key', 'auth-token', 'x-auth-token',
-            'cookie', 'set-cookie', 'csrf-token', 'x-csrf-token', 'access-token', 'x-access-token',
-            'token', 'bearer', 'basic', 'digest'
+            "authorization",
+            "api-key",
+            "api_key",
+            "x-api-key",
+            "auth-token",
+            "x-auth-token",
+            "cookie",
+            "set-cookie",
+            "csrf-token",
+            "x-csrf-token",
+            "access-token",
+            "x-access-token",
+            "token",
+            "bearer",
+            "basic",
+            "digest",
         ]
 
         sanitized = {}
@@ -75,7 +87,7 @@ class Mubi:
             key_lower = key.lower()
             is_sensitive = any(pattern in key_lower for pattern in sensitive_patterns)
             if is_sensitive:
-                sanitized[key] = '***REDACTED***'
+                sanitized[key] = "***REDACTED***"
             else:
                 sanitized[key] = value
 
@@ -93,14 +105,22 @@ class Mubi:
 
         # List of sensitive parameter names (case-insensitive)
         sensitive_params = {
-            'api_key', 'token', 'password', 'secret', 'auth', 'authorization',
-            'access_token', 'refresh_token', 'session_id', 'csrf_token'
+            "api_key",
+            "token",
+            "password",
+            "secret",
+            "auth",
+            "authorization",
+            "access_token",
+            "refresh_token",
+            "session_id",
+            "csrf_token",
         }
 
         sanitized = {}
         for key, value in params.items():
             if key.lower() in sensitive_params:
-                sanitized[key] = '***REDACTED***'
+                sanitized[key] = "***REDACTED***"
             else:
                 sanitized[key] = value
 
@@ -118,14 +138,22 @@ class Mubi:
 
         # List of sensitive field names (case-insensitive)
         sensitive_fields = {
-            'password', 'api_key', 'token', 'secret', 'auth', 'authorization',
-            'access_token', 'refresh_token', 'session_id', 'csrf_token'
+            "password",
+            "api_key",
+            "token",
+            "secret",
+            "auth",
+            "authorization",
+            "access_token",
+            "refresh_token",
+            "session_id",
+            "csrf_token",
         }
 
         sanitized = {}
         for key, value in json_data.items():
             if key.lower() in sensitive_fields:
-                sanitized[key] = '***REDACTED***'
+                sanitized[key] = "***REDACTED***"
             else:
                 sanitized[key] = value
 
@@ -137,7 +165,7 @@ class Mubi:
         # Ensure headers are not None and set Accept-Encoding to gzip
         if headers is None:
             headers = {}
-        headers.setdefault('Accept-Encoding', 'gzip')
+        headers.setdefault("Accept-Encoding", "gzip")
 
         # Log API call details
         xbmc.log(f"Making API call: {method} {url}", xbmc.LOGDEBUG)
@@ -158,11 +186,11 @@ class Mubi:
             total=3,
             backoff_factor=1,
             status_forcelist=[500, 502, 503, 504],
-            allowed_methods=["GET", "POST", "DELETE", "PUT", "PATCH"]
+            allowed_methods=["GET", "POST", "DELETE", "PUT", "PATCH"],
         )
         adapter = HTTPAdapter(max_retries=retries)
-        session.mount('https://', adapter)
-        session.mount('http://', adapter)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
 
         # Retry loop for rate limiting (429 responses)
         # Use longer waits to respect MUBI's rate limits (especially for bulk operations)
@@ -172,35 +200,29 @@ class Mubi:
         for attempt in range(max_rate_limit_retries + 1):
             try:
                 response = session.request(
-                    method,
-                    url,
-                    headers=headers,
-                    params=params,
-                    data=data,
-                    json=json,
-                    timeout=10
+                    method, url, headers=headers, params=params, data=data, json=json, timeout=10
                 )
 
                 # Handle rate limiting (429 Too Many Requests)
                 if response.status_code == 429:
                     if attempt < max_rate_limit_retries:
                         # Check for Retry-After header (can be seconds or HTTP date)
-                        retry_after = response.headers.get('Retry-After')
+                        retry_after = response.headers.get("Retry-After")
                         if retry_after:
                             try:
                                 wait_time = int(retry_after)
                             except ValueError:
                                 # Might be an HTTP date, use base exponential backoff
-                                wait_time = base_wait_time * (2 ** attempt)
+                                wait_time = base_wait_time * (2**attempt)
                         else:
                             # No Retry-After header, use exponential backoff
                             # 10s, 20s, 40s, 80s, 160s = up to 5+ minutes total
-                            wait_time = base_wait_time * (2 ** attempt)
+                            wait_time = base_wait_time * (2**attempt)
 
                         xbmc.log(
                             f"Rate limited (429). Waiting {wait_time}s before retry "
                             f"(attempt {attempt + 1}/{max_rate_limit_retries})",
-                            xbmc.LOGWARNING
+                            xbmc.LOGWARNING,
                         )
                         time.sleep(wait_time)
                         continue
@@ -254,10 +276,12 @@ class Mubi:
 
             # Check for invalid token indicators
             # MUBI API returns code 8 for "Invalid login token"
-            if response_data.get('code') == 8 or \
-               'invalid' in response_data.get('message', '').lower() and 'token' in response_data.get('message', '').lower() or \
-               'expired' in response_data.get('user_message', '').lower():
-
+            if (
+                response_data.get("code") == 8
+                or "invalid" in response_data.get("message", "").lower()
+                and "token" in response_data.get("message", "").lower()
+                or "expired" in response_data.get("user_message", "").lower()
+            ):
                 xbmc.log("Invalid or expired token detected. Logging out user.", xbmc.LOGWARNING)
 
                 # Log out the user
@@ -266,16 +290,16 @@ class Mubi:
                 # Show user-friendly notification
                 try:
                     dialog = xbmcgui.Dialog()
-                    user_message = response_data.get('user_message', 'Your session has expired. Please sign in again.')
+                    user_message = response_data.get("user_message", "Your session has expired. Please sign in again.")
                     dialog.notification(
                         "MUBI - Session Expired",
                         user_message,
                         xbmcgui.NOTIFICATION_WARNING,
-                        5000  # 5 second notification
+                        5000,  # 5 second notification
                     )
 
                     # Refresh the container to show the login option
-                    xbmc.executebuiltin('Container.Refresh')
+                    xbmc.executebuiltin("Container.Refresh")
                 except Exception as notification_error:
                     xbmc.log(f"Failed to show session expired notification: {notification_error}", xbmc.LOGWARNING)
 
@@ -311,7 +335,7 @@ class Mubi:
                     "MUBI",
                     "Having trouble reaching MUBI service. Please try again later.",
                     xbmcgui.NOTIFICATION_WARNING,
-                    5000  # 5 second notification
+                    5000,  # 5 second notification
                 )
             except Exception as notification_error:
                 # Fallback if notification fails
@@ -326,18 +350,12 @@ class Mubi:
             try:
                 dialog = xbmcgui.Dialog()
                 dialog.notification(
-                    "MUBI",
-                    "Service temporarily unavailable. Please try again later.",
-                    xbmcgui.NOTIFICATION_ERROR,
-                    5000
+                    "MUBI", "Service temporarily unavailable. Please try again later.", xbmcgui.NOTIFICATION_ERROR, 5000
                 )
             except Exception:
                 pass  # Silent fallback
 
             return None
-
-
-
 
     def get_cli_country(self):
         """
@@ -356,16 +374,12 @@ class Mubi:
 
         # Try multiple IP geolocation services for reliability
         # Each service returns just the country code as text, e.g. "US"
-        geo_services = [(url, 'text') for url in GEOIP_COUNTRY_URLS]
+        geo_services = [(url, "text") for url in GEOIP_COUNTRY_URLS]
 
         for service_url, response_type in geo_services:
             try:
                 xbmc.log(f"Detecting country via IP geolocation: {service_url}", xbmc.LOGDEBUG)
-                response = fresh_requests.get(
-                    service_url,
-                    headers={'User-Agent': self.UA},
-                    timeout=5
-                )
+                response = fresh_requests.get(service_url, headers={"User-Agent": self.UA}, timeout=5)
 
                 if response and response.status_code == 200:
                     country_code = response.text.strip().upper()
@@ -382,26 +396,26 @@ class Mubi:
         xbmc.log("IP geolocation failed, falling back to MUBI website detection", xbmc.LOGWARNING)
         try:
             headers = {
-                'User-Agent': self.UA,
-                'Cache-Control': 'no-cache, no-store, must-revalidate',
-                'Pragma': 'no-cache',
-                'Expires': '0',
+                "User-Agent": self.UA,
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0",
             }
 
             fresh_session = fresh_requests.Session()
             fresh_session.cookies.clear()
-            response = fresh_session.get(f'{MUBI_WEB_URL}/', headers=headers, timeout=10)
+            response = fresh_session.get(f"{MUBI_WEB_URL}/", headers=headers, timeout=10)
 
             if response and response.status_code == 200:
                 country = re.findall(r'"Client-Country":"([^"]+?)"', response.text)
-                cli_country = country[0] if country else 'PL'
+                cli_country = country[0] if country else "PL"
                 xbmc.log(f"Client country detected from MUBI: {cli_country}", xbmc.LOGINFO)
                 return cli_country
         except Exception as e:
             xbmc.log(f"MUBI fallback detection failed: {e}", xbmc.LOGERROR)
 
         xbmc.log("All country detection methods failed, defaulting to: PL", xbmc.LOGWARNING)
-        return 'PL'
+        return "PL"
 
     def get_cli_language(self):
         """
@@ -416,10 +430,10 @@ class Mubi:
         :rtype: str
         """
         # Use cached value from session manager if available
-        if hasattr(self.session_manager, 'client_language') and self.session_manager.client_language:
+        if hasattr(self.session_manager, "client_language") and self.session_manager.client_language:
             return self.session_manager.client_language
         # Default to English - works well with MUBI's international API
-        return 'en'
+        return "en"
 
     def hea_atv_gen(self):
         """
@@ -431,20 +445,19 @@ class Mubi:
         base_url = MUBI_WEB_URL  # This is used for the Referer and Origin headers
 
         return {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-            'Authorization': f'Bearer {self.session_manager.token}',  # Authorization token from session
-            'Anonymous_user_id': self.session_manager.device_id,  # Use session manager for device ID
-            'Client': 'web',
-            'Client-Accept-Audio-Codecs': 'aac,eac3,ac3,dts',  # Added Enhanced AC-3 and other surround sound codecs
-            'Client-Accept-Video-Codecs': 'h265,vp9,h264',  # Include support for video codecs
-            'Client-Country': self.session_manager.client_country,  # Client country from session
-            'accept-language' : self.session_manager.client_language,
-            'Referer': base_url,  # Add Referer for web-based requests
-            'Origin': base_url,  # Add Origin for web-based requests
-            'Accept-Encoding': 'gzip',
-            'accept': 'application/json'
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
+            "Authorization": f"Bearer {self.session_manager.token}",  # Authorization token from session
+            "Anonymous_user_id": self.session_manager.device_id,  # Use session manager for device ID
+            "Client": "web",
+            "Client-Accept-Audio-Codecs": "aac,eac3,ac3,dts",  # Added Enhanced AC-3 and other surround sound codecs
+            "Client-Accept-Video-Codecs": "h265,vp9,h264",  # Include support for video codecs
+            "Client-Country": self.session_manager.client_country,  # Client country from session
+            "accept-language": self.session_manager.client_language,
+            "Referer": base_url,  # Add Referer for web-based requests
+            "Origin": base_url,  # Add Origin for web-based requests
+            "Accept-Encoding": "gzip",
+            "accept": "application/json",
         }
-
 
     def hea_atv_auth(self, country: str = None):
         """
@@ -458,28 +471,28 @@ class Mubi:
         token = self.session_manager.token  # Use session manager
         if not token:
             xbmc.log("No token found", xbmc.LOGERROR)
-        headers['Authorization'] = f'Bearer {token}'
+        headers["Authorization"] = f"Bearer {token}"
         # Override country if specified (for multi-country playback)
         if country:
-            headers['Client-Country'] = country
+            headers["Client-Country"] = country
             xbmc.log(f"Using override country for API: {country}", xbmc.LOGINFO)
         return headers
 
     # Common browser User-Agents for rotation to avoid fingerprinting
     COMMON_USER_AGENTS = [
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:131.0) Gecko/20100101 Firefox/131.0',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0',
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:131.0) Gecko/20100101 Firefox/131.0",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0",
     ]
 
     # Countries to sync catalogues from (ISO 3166-1 alpha-2 codes)
     # Different countries have different film availability on MUBI
-    SYNC_COUNTRIES = ['CH', 'DE', 'US', 'GB', 'FR', 'JP']
+    SYNC_COUNTRIES = ["CH", "DE", "US", "GB", "FR", "JP"]
 
     def _get_random_user_agent(self):
         """
@@ -507,13 +520,13 @@ class Mubi:
         client_country = country_code if country_code else self.session_manager.client_country
 
         return {
-            'Referer': base_url,
-            'Origin': base_url,
-            'User-Agent': self._get_random_user_agent(),
-            'Client': 'web',
-            'Client-Accept-Video-Codecs': 'h265,vp9,h264',
-            'Client-Country': client_country,
-            'accept-language': self.get_cli_language()
+            "Referer": base_url,
+            "Origin": base_url,
+            "User-Agent": self._get_random_user_agent(),
+            "Client": "web",
+            "Client-Accept-Video-Codecs": "h265,vp9,h264",
+            "Client-Country": client_country,
+            "accept-language": self.get_cli_language(),
         }
 
     def hea_gen(self):
@@ -530,16 +543,16 @@ class Mubi:
             xbmc.log("No token found for web headers", xbmc.LOGERROR)
 
         return {
-            'Referer': base_url,
-            'Origin': base_url,
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-            'Authorization': f'Bearer {token}',
-            'Anonymous_user_id': self.session_manager.device_id,
-            'Client': 'web',
-            'Client-Accept-Audio-Codecs': 'eac3,aac',
-            'Client-Accept-Video-Codecs': 'h265,vp9,h264',
-            'Client-Country': self.session_manager.client_country,
-            'accept-language': self.get_cli_language()
+            "Referer": base_url,
+            "Origin": base_url,
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
+            "Authorization": f"Bearer {token}",
+            "Anonymous_user_id": self.session_manager.device_id,
+            "Client": "web",
+            "Client-Accept-Audio-Codecs": "eac3,aac",
+            "Client-Accept-Video-Codecs": "h265,vp9,h264",
+            "Client-Country": self.session_manager.client_country,
+            "accept-language": self.get_cli_language(),
         }
 
     def get_link_code(self):
@@ -549,7 +562,7 @@ class Mubi:
         :return: Dictionary with 'auth_token' and 'link_code'.
         :rtype: dict
         """
-        response = self._make_api_call('GET', 'v4/link_code', headers=self.hea_atv_gen())
+        response = self._make_api_call("GET", "v4/link_code", headers=self.hea_atv_gen())
         return self._safe_json_parse(response, "authentication link code generation")
 
     def authenticate(self, auth_token):
@@ -561,18 +574,16 @@ class Mubi:
         :return: Authentication response data if successful, None otherwise.
         :rtype: dict or None
         """
-        data = {'auth_token': auth_token}
-        response = self._make_api_call(
-            'POST', 'v4/authenticate', headers=self.hea_atv_gen(), json=data
-        )
+        data = {"auth_token": auth_token}
+        response = self._make_api_call("POST", "v4/authenticate", headers=self.hea_atv_gen(), json=data)
 
         response_data = self._safe_json_parse(response, "user authentication")
 
         if response_data:
             # Check if token and user data are present in the response
-            if 'token' in response_data and 'user' in response_data:
-                token = response_data['token']
-                user_id = response_data['user']['id']  # Extract user_id from the response
+            if "token" in response_data and "user" in response_data:
+                token = response_data["token"]
+                user_id = response_data["user"]["id"]  # Extract user_id from the response
 
                 # Set the token and user_id in the session
                 self.session_manager.set_logged_in(token, str(user_id))  # Store both token and user_id
@@ -580,13 +591,13 @@ class Mubi:
                 xbmc.log("User authenticated successfully", xbmc.LOGDEBUG)
                 return response_data  # Return the full response data
             else:
-                xbmc.log(f"Authentication failed: {response_data.get('message', 'No error message provided')}", xbmc.LOGERROR)
+                xbmc.log(
+                    f"Authentication failed: {response_data.get('message', 'No error message provided')}", xbmc.LOGERROR
+                )
         else:
             xbmc.log("Authentication failed: No response from server", xbmc.LOGERROR)
 
         return None  # Return None if authentication failed
-
-
 
     def log_out(self):
         """
@@ -595,14 +606,14 @@ class Mubi:
         :return: True if logout was successful, False otherwise.
         :rtype: bool
         """
-        response = self._make_api_call('DELETE', 'v4/sessions', headers=self.hea_atv_auth())
+        response = self._make_api_call("DELETE", "v4/sessions", headers=self.hea_atv_auth())
         if response and response.status_code == 200:
             return True
         else:
             return False
+
     def _fetch_films_for_country(
-        self, country_code: str, playable_only: bool = True, page_callback=None,
-        global_film_ids: set = None
+        self, country_code: str, playable_only: bool = True, page_callback=None, global_film_ids: set = None
     ) -> Tuple[set, dict, int, int]:
         """
         Fetches all films for a specific country from the MUBI API.
@@ -615,7 +626,7 @@ class Mubi:
                                 Used to count truly new films for progress display.
         :return: Tuple of (film_ids set, film_data dict {id: film_data}, total_count, pages_fetched)
         """
-        endpoint = 'v4/browse/films'
+        endpoint = "v4/browse/films"
         film_ids = set()
         film_data_map = {}  # {film_id: film_data}
         page = 1
@@ -632,13 +643,13 @@ class Mubi:
             headers = self.hea_gen_anonymous(country_code=country_code)
 
             params = {
-                'page': page,
-                'sort': 'title',
+                "page": page,
+                "sort": "title",
             }
             if playable_only:
-                params['playable'] = 'true'
+                params["playable"] = "true"
 
-            response = self._make_api_call('GET', endpoint=endpoint, headers=headers, params=params)
+            response = self._make_api_call("GET", endpoint=endpoint, headers=headers, params=params)
 
             if not response:
                 xbmc.log(f"[{country_code}] Failed to retrieve page {page}", xbmc.LOGERROR)
@@ -648,20 +659,20 @@ class Mubi:
             if not data:
                 break
 
-            films = data.get('films', [])
-            meta = data.get('meta', {})
+            films = data.get("films", [])
+            meta = data.get("meta", {})
             pages_fetched += 1
 
             # Get total count from first page
             if page == 1:
-                total_count = meta.get('total_count', 0)
-                total_pages = meta.get('total_pages', 0)
+                total_count = meta.get("total_count", 0)
+                total_pages = meta.get("total_pages", 0)
                 xbmc.log(f"[{country_code}] API reports {total_count} films across {total_pages} pages", xbmc.LOGINFO)
 
             # Process films
             globally_new_films = 0  # Films not seen in ANY country yet
             for film_entry in films:
-                film_id = film_entry.get('id')
+                film_id = film_entry.get("id")
                 if film_id and film_id not in film_ids:
                     film_ids.add(film_id)
                     film_data_map[film_id] = film_entry
@@ -677,7 +688,7 @@ class Mubi:
                     break
 
             # Check for next page
-            next_page = meta.get('next_page')
+            next_page = meta.get("next_page")
             if next_page:
                 page = next_page
                 # Small delay between pages to avoid rate limiting
@@ -687,10 +698,7 @@ class Mubi:
 
             # Safety limit
             if pages_fetched > 100:
-                xbmc.log(
-                    f"[{country_code}] Safety limit reached at {pages_fetched} pages",
-                    xbmc.LOGWARNING
-                )
+                xbmc.log(f"[{country_code}] Safety limit reached at {pages_fetched} pages", xbmc.LOGWARNING)
                 break
 
         xbmc.log(f"[{country_code}] Completed: {len(film_ids)} unique films from {pages_fetched} pages", xbmc.LOGINFO)
@@ -705,11 +713,11 @@ class Mubi:
         # But here 'film_data' is just the dict from the API (plus __available_countries__)
 
         # Check for available_countries (injected by DataSource OR from GitHub JSON)
-        available_countries = film_data.get('available_countries', {})
+        available_countries = film_data.get("available_countries", {})
 
         # Create film object
         # We need to wrap it because get_film_metadata expects {'film': ...} structure
-        film_wrapper = {'film': film_data}
+        film_wrapper = {"film": film_data}
         return self.get_film_metadata(film_wrapper, available_countries=available_countries)
 
     def get_all_films(self, playable_only=True, progress_callback=None, countries=None, data_source=None):
@@ -729,36 +737,38 @@ class Mubi:
         # 1. Fetch (DataSource)
         # Use provided data source or default to MubiApiDataSource
         source = data_source if data_source else MubiApiDataSource(self)
-        
+
         # progress_callback is handled inside data source for the fetching phase
-        raw_films = source.get_films(playable_only=playable_only, progress_callback=progress_callback, countries=countries)
-        
+        raw_films = source.get_films(
+            playable_only=playable_only, progress_callback=progress_callback, countries=countries
+        )
+
         xbmc.log(f"Pipeline: Fetched {len(raw_films)} raw films.", xbmc.LOGINFO)
 
         # 2. Filter (FilmFilter)
         film_filter = FilmFilter()
         filtered_films = film_filter.filter_films(raw_films)
-        
+
         xbmc.log(f"Pipeline: Filtering retained {len(filtered_films)} films.", xbmc.LOGINFO)
 
         # 3. Hydrate & 4. Add to Library
         all_films_library = Library()
-        
+
         if progress_callback:
-             try:
-                 progress_callback(
-                     current_films=len(raw_films), # Total known
-                     total_films=len(filtered_films), # Films to process
-                     current_country=len(self.SYNC_COUNTRIES), # Done
-                     total_countries=len(self.SYNC_COUNTRIES),
-                     country_code='PROCESSING'
-                 )
-             except Exception:
-                 pass
-        
+            try:
+                progress_callback(
+                    current_films=len(raw_films),  # Total known
+                    total_films=len(filtered_films),  # Films to process
+                    current_country=len(self.SYNC_COUNTRIES),  # Done
+                    total_countries=len(self.SYNC_COUNTRIES),
+                    country_code="PROCESSING",
+                )
+            except Exception:
+                pass
+
         xbmc.log(f"Processing {len(filtered_films)} films into library...", xbmc.LOGINFO)
         total_films_added = 0
-        
+
         for film_data in filtered_films:
             film = self.process_film_data(film_data)
             if film:
@@ -767,7 +777,6 @@ class Mubi:
 
         xbmc.log(f"Successfully added {total_films_added} films to library", xbmc.LOGINFO)
         return all_films_library
-
 
     def get_watch_list(self):
         """
@@ -781,10 +790,10 @@ class Mubi:
 
             # Process and add each film to the library
             for film_item in films_data:
-                this_film = film_item.get('film')
+                this_film = film_item.get("film")
                 if not this_film:
                     continue
-                consumable = this_film.get('consumable')
+                consumable = this_film.get("consumable")
                 if consumable is not None:
                     film = self.get_film_metadata(film_item)
                     if film:
@@ -795,9 +804,6 @@ class Mubi:
             xbmc.log(f"Error retrieving films from the watchlist: {e}", xbmc.LOGERROR)
 
         return self.library
-
-
-
 
     def get_films_in_watchlist(self):
         """
@@ -815,8 +821,8 @@ class Mubi:
         if not data:
             return []  # Return empty list for graceful degradation
 
-        meta = data.get('meta')
-        total_count = meta.get('total_count') if meta else 0
+        meta = data.get("meta")
+        total_count = meta.get("total_count") if meta else 0
 
         if total_count == 0:
             return []
@@ -826,13 +832,10 @@ class Mubi:
         data = self._safe_json_parse(response, "watchlist films retrieval")
 
         if data:
-            wishes = data.get('wishes', [])
+            wishes = data.get("wishes", [])
             all_film_items.extend(wishes)
 
         return all_film_items
-
-
-
 
     def _call_wishlist_api(self, per_page: int):
         """
@@ -841,29 +844,14 @@ class Mubi:
         :return: result
         :rtype: json
         """
-        endpoint = 'v4/wishes'
+        endpoint = "v4/wishes"
         headers = self.hea_atv_auth()
-        params = {
-            'user_id': self.session_manager.user_id,
-            'per_page': per_page
-        }
+        params = {"user_id": self.session_manager.user_id, "per_page": per_page}
 
-        response = self._make_api_call('GET', endpoint=endpoint, headers=headers, params=params)
+        response = self._make_api_call("GET", endpoint=endpoint, headers=headers, params=params)
         if not response:
             xbmc.log("Failed to retrieve films from your watchlist", xbmc.LOGERROR)
         return response
-
-
-
-
-
-
-
-
-
-
-
-
 
     def get_film_metadata(self, film_data: dict, available_countries: dict = None) -> Film:
         """
@@ -875,16 +863,16 @@ class Mubi:
         :return: Film instance or None if not valid or is a series
         """
         try:
-            film_info = film_data.get('film', {})
+            film_info = film_data.get("film", {})
             if not film_info:
                 return None
 
             # Check if this is a series (like inspiration code does)
-            if 'series' in film_info and film_info['series'] is not None:
+            if "series" in film_info and film_info["series"] is not None:
                 return None  # Skip series content for film sync
 
-            available_at = (film_info.get('consumable') or {}).get('available_at')
-            expires_at = (film_info.get('consumable') or {}).get('expires_at')
+            available_at = (film_info.get("consumable") or {}).get("available_at")
+            expires_at = (film_info.get("consumable") or {}).get("expires_at")
             if available_at and expires_at:
                 available_at_dt = dateutil.parser.parse(available_at)
                 expires_at_dt = dateutil.parser.parse(expires_at)
@@ -893,8 +881,8 @@ class Mubi:
                     return None
 
             # Enhanced plot descriptions: Use default_editorial if available, fallback to short_synopsis
-            default_editorial = film_info.get('default_editorial', '')
-            short_synopsis = film_info.get('short_synopsis', '')
+            default_editorial = film_info.get("default_editorial", "")
+            short_synopsis = film_info.get("short_synopsis", "")
 
             if default_editorial:
                 enhanced_plot = default_editorial
@@ -906,8 +894,8 @@ class Mubi:
             # Legacy manual MPAA mapping removed. Plugin now consumes 'mpaa' field from backend sync.
 
             # Enhanced rating precision: Use 10-point scale if available, fallback to 5-point
-            rating_10_point = film_info.get('average_rating_out_of_ten', 0)
-            rating_5_point = film_info.get('average_rating', 0)
+            rating_10_point = film_info.get("average_rating_out_of_ten", 0)
+            rating_5_point = film_info.get("average_rating", 0)
 
             if rating_10_point:
                 final_rating = rating_10_point
@@ -922,55 +910,55 @@ class Mubi:
             audio_languages, subtitle_languages, media_features = self._get_playback_languages(film_info)
 
             # Extract press_quote as tagline
-            press_quote = film_info.get('press_quote', '')
+            press_quote = film_info.get("press_quote", "")
 
             # Extract premiered date from consumable.available_at
-            premiered = ''
-            consumable = film_info.get('consumable') or {}
+            premiered = ""
+            consumable = film_info.get("consumable") or {}
             if isinstance(consumable, dict):
-                available_at = consumable.get('available_at', '')
+                available_at = consumable.get("available_at", "")
                 if available_at:
                     # Convert ISO format "2025-04-15T07:00:00Z" to "2025-04-15"
                     try:
-                        premiered = available_at.split('T')[0] if 'T' in available_at else available_at
+                        premiered = available_at.split("T")[0] if "T" in available_at else available_at
                     except Exception:
-                        premiered = ''
+                        premiered = ""
 
             # Extract content warnings as list of names
-            content_warnings_raw = film_info.get('content_warnings', [])
+            content_warnings_raw = film_info.get("content_warnings", [])
             content_warnings = []
             if isinstance(content_warnings_raw, list):
                 for warning in content_warnings_raw:
-                    if isinstance(warning, dict) and warning.get('name'):
-                        content_warnings.append(warning['name'])
+                    if isinstance(warning, dict) and warning.get("name"):
+                        content_warnings.append(warning["name"])
 
             # Extract Bayesian rating (if available from GitHub sync)
             bayesian_rating = None
             bayesian_votes = None
-            ratings = film_info.get('ratings', [])
+            ratings = film_info.get("ratings", [])
             if isinstance(ratings, list):
                 for r in ratings:
-                    if isinstance(r, dict) and r.get('source') == 'bayesian':
-                        bayesian_rating = r.get('score_over_10')
-                        bayesian_votes = r.get('voters')
+                    if isinstance(r, dict) and r.get("source") == "bayesian":
+                        bayesian_rating = r.get("score_over_10")
+                        bayesian_votes = r.get("voters")
                         break
 
             metadata = Metadata(
-                title=film_info.get('title', ''),
-                director=[d['name'] for d in film_info.get('directors', [])],
-                year=film_info.get('year', ''),
-                duration=film_info.get('duration', 0),
-                country=film_info.get('historic_countries', []),
+                title=film_info.get("title", ""),
+                director=[d["name"] for d in film_info.get("directors", [])],
+                year=film_info.get("year", ""),
+                duration=film_info.get("duration", 0),
+                country=film_info.get("historic_countries", []),
                 plot=enhanced_plot,  # Use enhanced editorial content
                 plotoutline=short_outline,  # Keep short synopsis for outline
-                genre=film_info.get('genres', []),
-                originaltitle=film_info.get('original_title', ''),
+                genre=film_info.get("genres", []),
+                originaltitle=film_info.get("original_title", ""),
                 rating=final_rating,  # Use enhanced 10-point rating
-                votes=film_info.get('number_of_ratings', 0),
-                dateadded=datetime.date.today().strftime('%Y-%m-%d'),
+                votes=film_info.get("number_of_ratings", 0),
+                dateadded=datetime.date.today().strftime("%Y-%m-%d"),
                 trailer=self._get_best_trailer_url(film_info),
                 image=self._get_best_thumbnail_url(film_info),
-                mpaa=film_info.get('mpaa'),  # Use pre-calculated mpaa from sync (if available)
+                mpaa=film_info.get("mpaa"),  # Use pre-calculated mpaa from sync (if available)
                 artwork_urls=artwork_urls,  # Add all artwork URLs
                 audio_languages=audio_languages,  # Available audio languages
                 subtitle_languages=subtitle_languages,  # Available subtitle languages
@@ -979,16 +967,16 @@ class Mubi:
                 content_warnings=content_warnings,  # Content warnings as library tags
                 tagline=press_quote,  # Press quote as tagline
                 bayesian_rating=bayesian_rating,
-                bayesian_votes=bayesian_votes
+                bayesian_votes=bayesian_votes,
             )
 
             return Film(
-                mubi_id=film_info.get('id'),
-                title=film_info.get('title', ''),
+                mubi_id=film_info.get("id"),
+                title=film_info.get("title", ""),
                 artwork=self._get_best_thumbnail_url(film_info),
-                web_url=film_info.get('web_url', ''),
+                web_url=film_info.get("web_url", ""),
                 metadata=metadata,
-                available_countries=available_countries or {}
+                available_countries=available_countries or {},
             )
         except Exception as e:
             xbmc.log(f"Error parsing film metadata: {e}", xbmc.LOGERROR)
@@ -1003,27 +991,27 @@ class Mubi:
         """
         try:
             # Check for enhanced stills with retina quality
-            stills = film_info.get('stills', {})
+            stills = film_info.get("stills", {})
             if isinstance(stills, dict):
                 # Prefer retina quality for higher resolution
-                retina_url = stills.get('retina', '')
+                retina_url = stills.get("retina", "")
                 if retina_url:
                     return retina_url
 
                 # Fallback to standard quality
-                standard_url = stills.get('standard', '')
+                standard_url = stills.get("standard", "")
                 if standard_url:
                     return standard_url
 
             # Final fallback to still_url (handle potential object format)
-            still_val = film_info.get('still_url')
+            still_val = film_info.get("still_url")
             if isinstance(still_val, dict):
-                return still_val.get('url', '')
-            return still_val or ''
+                return still_val.get("url", "")
+            return still_val or ""
 
         except Exception as e:
             xbmc.log(f"Error getting thumbnail URL: {e}", xbmc.LOGERROR)
-            return film_info.get('still_url', '')  # Safe fallback
+            return film_info.get("still_url", "")  # Safe fallback
 
     def _get_all_artwork_urls(self, film_info: dict) -> dict:
         """
@@ -1047,65 +1035,65 @@ class Mubi:
                 return {}
 
             # Thumbnail/Landscape images from stills
-            stills = film_info.get('stills', {})
+            stills = film_info.get("stills", {})
             if isinstance(stills, dict):
                 # Use retina quality for thumb (landscape)
-                if stills.get('retina'):
-                    artwork_urls['thumb'] = stills['retina']
-                elif stills.get('standard'):
-                    artwork_urls['thumb'] = stills['standard']
+                if stills.get("retina"):
+                    artwork_urls["thumb"] = stills["retina"]
+                elif stills.get("standard"):
+                    artwork_urls["thumb"] = stills["standard"]
 
             # Fallback to still_url if no stills available
-            if 'thumb' not in artwork_urls:
-                still_val = film_info.get('still_url')
+            if "thumb" not in artwork_urls:
+                still_val = film_info.get("still_url")
                 if isinstance(still_val, dict):
-                    still_url = still_val.get('url')
+                    still_url = still_val.get("url")
                 else:
                     still_url = still_val
-                
+
                 if still_url:
-                    artwork_urls['thumb'] = still_url
+                    artwork_urls["thumb"] = still_url
 
             # Extract artwork from artworks[] array - better quality poster and fanart
-            artworks = film_info.get('artworks', [])
+            artworks = film_info.get("artworks", [])
             if isinstance(artworks, list):
                 for artwork in artworks:
                     if not isinstance(artwork, dict):
                         continue
 
-                    artwork_format = artwork.get('format', '')
-                    image_url = artwork.get('image_url', '')
+                    artwork_format = artwork.get("format", "")
+                    image_url = artwork.get("image_url", "")
 
                     if not image_url:
                         continue
 
                     # Poster from cover_artwork_vertical (vertical/portrait format)
-                    if artwork_format == 'cover_artwork_vertical' and 'poster' not in artwork_urls:
-                        artwork_urls['poster'] = image_url
+                    if artwork_format == "cover_artwork_vertical" and "poster" not in artwork_urls:
+                        artwork_urls["poster"] = image_url
 
                     # Fanart from centered_background (large background image)
-                    elif artwork_format == 'centered_background' and 'fanart' not in artwork_urls:
-                        artwork_urls['fanart'] = image_url
+                    elif artwork_format == "centered_background" and "fanart" not in artwork_urls:
+                        artwork_urls["fanart"] = image_url
 
                     # Banner from cover_artwork_horizontal (wide horizontal image for list views)
-                    elif artwork_format == 'cover_artwork_horizontal' and 'banner' not in artwork_urls:
-                        artwork_urls['banner'] = image_url
+                    elif artwork_format == "cover_artwork_horizontal" and "banner" not in artwork_urls:
+                        artwork_urls["banner"] = image_url
 
             # Fallback: Portrait image for poster if not found in artworks[]
-            if 'poster' not in artwork_urls:
-                port_val = film_info.get('portrait_image')
+            if "poster" not in artwork_urls:
+                port_val = film_info.get("portrait_image")
                 if isinstance(port_val, dict):
-                    portrait_image = port_val.get('url')
+                    portrait_image = port_val.get("url")
                 else:
                     portrait_image = port_val
-                
+
                 if portrait_image:
-                    artwork_urls['poster'] = portrait_image
+                    artwork_urls["poster"] = portrait_image
 
             # Title treatment for clear logo
-            title_treatment = film_info.get('title_treatment_url')
+            title_treatment = film_info.get("title_treatment_url")
             if title_treatment:
-                artwork_urls['clearlogo'] = title_treatment
+                artwork_urls["clearlogo"] = title_treatment
 
             return artwork_urls
 
@@ -1113,8 +1101,8 @@ class Mubi:
             xbmc.log(f"Error extracting artwork URLs: {e}", xbmc.LOGERROR)
             # Safe fallback - handle None film_info gracefully
             if film_info and isinstance(film_info, dict):
-                still_url = film_info.get('still_url', '')
-                return {'thumb': still_url} if still_url else {}
+                still_url = film_info.get("still_url", "")
+                return {"thumb": still_url} if still_url else {}
             else:
                 return {}
 
@@ -1127,22 +1115,22 @@ class Mubi:
         """
         try:
             # Check for optimised trailers with multiple qualities
-            optimised_trailers = film_info.get('optimised_trailers', [])
+            optimised_trailers = film_info.get("optimised_trailers", [])
             if isinstance(optimised_trailers, list) and optimised_trailers:
                 # Prefer highest quality available: 1080p > 720p > 240p
-                for quality in ['1080p', '720p', '240p']:
+                for quality in ["1080p", "720p", "240p"]:
                     for trailer in optimised_trailers:
-                        if isinstance(trailer, dict) and trailer.get('profile') == quality:
-                            trailer_url = trailer.get('url', '')
+                        if isinstance(trailer, dict) and trailer.get("profile") == quality:
+                            trailer_url = trailer.get("url", "")
                             if trailer_url:
                                 return trailer_url
 
             # Fallback to original trailer_url
-            return film_info.get('trailer_url', '')
+            return film_info.get("trailer_url", "")
 
         except Exception as e:
             xbmc.log(f"Error getting trailer URL: {e}", xbmc.LOGERROR)
-            return film_info.get('trailer_url', '')  # Safe fallback
+            return film_info.get("trailer_url", "")  # Safe fallback
 
     def _get_playback_languages(self, film_info: dict) -> tuple:
         """
@@ -1153,24 +1141,24 @@ class Mubi:
         """
         try:
             # Check top-level playback_languages first (New Scehma)
-            playback_languages = film_info.get('playback_languages')
-            
+            playback_languages = film_info.get("playback_languages")
+
             # Fallback to nested consumable (API / Old Schema)
             if not playback_languages:
-                consumable = film_info.get('consumable') or {}
+                consumable = film_info.get("consumable") or {}
                 if isinstance(consumable, dict):
-                    playback_languages = consumable.get('playback_languages')
+                    playback_languages = consumable.get("playback_languages")
 
             if not isinstance(playback_languages, dict):
                 return [], [], []
 
             # Extract language and feature information
-            audio_languages = playback_languages.get('audio_options', [])
-            subtitle_languages = playback_languages.get('subtitle_options', [])
-            media_features = playback_languages.get('media_features', [])
+            audio_languages = playback_languages.get("audio_options", [])
+            subtitle_languages = playback_languages.get("subtitle_options", [])
+            media_features = playback_languages.get("media_features", [])
 
             # Also check for extended_audio_options if available
-            extended_audio = playback_languages.get('extended_audio_options', [])
+            extended_audio = playback_languages.get("extended_audio_options", [])
             if extended_audio and isinstance(extended_audio, list):
                 # Merge with audio_options, avoiding duplicates
                 all_audio = list(set(audio_languages + extended_audio))
@@ -1186,11 +1174,6 @@ class Mubi:
         except Exception as e:
             xbmc.log(f"Error extracting playback languages: {e}", xbmc.LOGERROR)
             return [], [], []
-
-
-
-
-
 
     def get_secure_stream_info(self, vid: str, film_country: Optional[str] = None) -> dict:
         """
@@ -1213,7 +1196,7 @@ class Mubi:
             # Step 1: Attempt to check film viewing availability with parental lock
             # Make a direct request to check for geo-restriction errors
             viewing_url = f"{self.apiURL}v4/films/{vid}/viewing"
-            params = {'parental_lock_enabled': 'true'}
+            params = {"parental_lock_enabled": "true"}
 
             try:
                 response = requests.post(viewing_url, headers=headers, params=params, timeout=10)
@@ -1223,28 +1206,32 @@ class Mubi:
                 if response.status_code == 422:
                     try:
                         error_data = response.json()
-                        if error_data.get('code') == 50 or 'not authorized' in error_data.get('message', '').lower():
+                        if error_data.get("code") == 50 or "not authorized" in error_data.get("message", "").lower():
                             xbmc.log(f"Geo-restriction detected: {error_data}", xbmc.LOGWARNING)
                             # Include the film's available country in the error message
                             if film_country:
                                 country_name = self.COUNTRY_NAMES.get(film_country, film_country)
-                                error_msg = f"Film not available in your country. Use a VPN to {country_name} to watch it."
+                                error_msg = (
+                                    f"Film not available in your country. Use a VPN to {country_name} to watch it."
+                                )
                             else:
                                 error_msg = "Film not available in your country. Use a VPN to watch it."
-                            return {'error': error_msg}
+                            return {"error": error_msg}
                     except (ValueError, KeyError):
                         pass  # Not a JSON response or missing fields
 
                 # For other non-200 responses, log and continue (some may be recoverable)
                 if response.status_code != 200:
-                    xbmc.log(f"Viewing availability check returned {response.status_code}: {response.text}", xbmc.LOGWARNING)
+                    xbmc.log(
+                        f"Viewing availability check returned {response.status_code}: {response.text}", xbmc.LOGWARNING
+                    )
 
             except requests.exceptions.RequestException as e:
                 xbmc.log(f"Error checking viewing availability: {e}", xbmc.LOGWARNING)
 
             # Step 2: Handle Pre-roll (if any)
             preroll_url = f"{self.apiURL}v4/prerolls/viewings"
-            preroll_data = {'viewing_film_id': int(vid)}
+            preroll_data = {"viewing_film_id": int(vid)}
             preroll_response = self._make_api_call("POST", full_url=preroll_url, headers=headers, json=preroll_data)
 
             # Pre-roll is optional, so even if it fails, we can continue
@@ -1263,11 +1250,11 @@ class Mubi:
 
             if not secure_data or "url" not in secure_data:
                 if secure_data:
-                    message = secure_data.get('user_message', 'Unable to retrieve secure URL')
+                    message = secure_data.get("user_message", "Unable to retrieve secure URL")
                 else:
-                    message = 'Service temporarily unavailable'
+                    message = "Service temporarily unavailable"
                 xbmc.log(f"Error retrieving secure stream info: {message}", xbmc.LOGERROR)
-                return {'error': message}
+                return {"error": message}
 
             # Log the complete raw response from Mubi for audio analysis
             xbmc.log("=== RAW MUBI SECURE URL RESPONSE ===", xbmc.LOGINFO)
@@ -1276,22 +1263,21 @@ class Mubi:
 
             # Step 4: Extract stream URL and DRM info (keep all URLs and any additional metadata)
             stream_info = {
-                'stream_url': secure_data['url'],  # The primary stream URL
-                'urls': secure_data.get('urls', []),  # Additional URLs to select from
-                'license_key': generate_drm_license_key(self.session_manager.token, self.session_manager.user_id)
+                "stream_url": secure_data["url"],  # The primary stream URL
+                "urls": secure_data.get("urls", []),  # Additional URLs to select from
+                "license_key": generate_drm_license_key(self.session_manager.token, self.session_manager.user_id),
             }
 
             # Preserve any additional metadata that might contain audio information
             for key, value in secure_data.items():
-                if key not in ['url', 'urls']:
+                if key not in ["url", "urls"]:
                     stream_info[key] = value
 
             return stream_info
 
         except Exception as e:
             xbmc.log(f"Error retrieving secure stream info: {e}", xbmc.LOGERROR)
-            return {'error': 'Service temporarily unavailable while retrieving stream info'}
-
+            return {"error": "Service temporarily unavailable while retrieving stream info"}
 
     def select_best_stream(self, stream_info):
         """
@@ -1308,34 +1294,34 @@ class Mubi:
             # Log available streams with detailed information
             xbmc.log(f"Number of available streams: {len(stream_info.get('urls', []))}", xbmc.LOGINFO)
 
-            for i, stream in enumerate(stream_info.get('urls', [])):
-                xbmc.log(f"Stream {i+1}:", xbmc.LOGINFO)
+            for i, stream in enumerate(stream_info.get("urls", [])):
+                xbmc.log(f"Stream {i + 1}:", xbmc.LOGINFO)
                 xbmc.log(f"  - URL: {stream.get('src', 'N/A')}", xbmc.LOGINFO)
                 xbmc.log(f"  - Content Type: {stream.get('content_type', 'N/A')}", xbmc.LOGINFO)
 
                 # Log all available keys in the stream object
                 for key, value in stream.items():
-                    if key not in ['src', 'content_type']:
+                    if key not in ["src", "content_type"]:
                         xbmc.log(f"  - {key}: {value}", xbmc.LOGINFO)
 
             # Also log any additional metadata that might contain audio info
             for key, value in stream_info.items():
-                if key not in ['urls', 'stream_url', 'license_key']:
+                if key not in ["urls", "stream_url", "license_key"]:
                     xbmc.log(f"Additional stream metadata - {key}: {value}", xbmc.LOGINFO)
 
             xbmc.log("=== END STREAM ANALYSIS ===", xbmc.LOGINFO)
 
             # Prefer MPEG-DASH over HLS
-            for stream in stream_info['urls']:
-                if stream['content_type'] == 'application/dash+xml':
+            for stream in stream_info["urls"]:
+                if stream["content_type"] == "application/dash+xml":
                     xbmc.log(f"Selected DASH stream: {stream['src']}", xbmc.LOGINFO)
-                    return stream['src']
+                    return stream["src"]
 
             # If DASH not found, fall back to HLS
-            for stream in stream_info['urls']:
-                if stream['content_type'] == 'application/x-mpegURL':
+            for stream in stream_info["urls"]:
+                if stream["content_type"] == "application/x-mpegURL":
                     xbmc.log(f"Selected HLS stream: {stream['src']}", xbmc.LOGINFO)
-                    return stream['src']
+                    return stream["src"]
 
             # No suitable stream found
             xbmc.log("No suitable stream found.", xbmc.LOGERROR)

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -9,27 +9,23 @@
 
 
 import datetime
+import json
+import random
+import re
+import time
+from typing import Optional, Tuple
+
 import dateutil.parser
 import requests
-import json
-import hashlib
-import base64
-from collections import namedtuple
 import xbmc
 import xbmcgui
-import re
-import random
-from urllib.parse import urljoin
-from urllib.parse import urlencode
-import time
-import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from typing import Optional, Tuple
-from .metadata import Metadata
+
+from .constants import GEOIP_COUNTRY_URLS, MUBI_API_URL, MUBI_WEB_URL
 from .film import Film
-from .constants import MUBI_API_URL, MUBI_WEB_URL, GEOIP_COUNTRY_URLS
 from .library import Library
+from .metadata import Metadata
 from .playback import generate_drm_license_key
 
 
@@ -707,9 +703,7 @@ class Mubi:
         """
         # The data source injects keys into the raw dict.
         # But here 'film_data' is just the dict from the API (plus __available_countries__)
-        
-        fid = film_data.get('id')
-    
+
         # Check for available_countries (injected by DataSource OR from GitHub JSON)
         available_countries = film_data.get('available_countries', {})
 
@@ -791,7 +785,7 @@ class Mubi:
                 if not this_film:
                     continue
                 consumable = this_film.get('consumable')
-                if consumable != None:
+                if consumable is not None:
                     film = self.get_film_metadata(film_item)
                     if film:
                         self.library.add_film(film)
@@ -856,7 +850,7 @@ class Mubi:
 
         response = self._make_api_call('GET', endpoint=endpoint, headers=headers, params=params)
         if not response:
-            xbmc.log(f"Failed to retrieve films from your watchlist", xbmc.LOGERROR)
+            xbmc.log("Failed to retrieve films from your watchlist", xbmc.LOGERROR)
         return response
 
 
@@ -910,7 +904,6 @@ class Mubi:
             short_outline = short_synopsis  # Keep short synopsis for outline
 
             # Legacy manual MPAA mapping removed. Plugin now consumes 'mpaa' field from backend sync.
-            mpaa_rating = None
 
             # Enhanced rating precision: Use 10-point scale if available, fallback to 5-point
             rating_10_point = film_info.get('average_rating_out_of_ten', 0)
@@ -1277,9 +1270,9 @@ class Mubi:
                 return {'error': message}
 
             # Log the complete raw response from Mubi for audio analysis
-            xbmc.log(f"=== RAW MUBI SECURE URL RESPONSE ===", xbmc.LOGINFO)
+            xbmc.log("=== RAW MUBI SECURE URL RESPONSE ===", xbmc.LOGINFO)
             xbmc.log(f"Complete secure_data from Mubi API: {secure_data}", xbmc.LOGINFO)
-            xbmc.log(f"=== END RAW RESPONSE ===", xbmc.LOGINFO)
+            xbmc.log("=== END RAW RESPONSE ===", xbmc.LOGINFO)
 
             # Step 4: Extract stream URL and DRM info (keep all URLs and any additional metadata)
             stream_info = {
@@ -1309,7 +1302,7 @@ class Mubi:
         """
         try:
             # Log the complete stream info for debugging
-            xbmc.log(f"=== MUBI STREAM ANALYSIS ===", xbmc.LOGINFO)
+            xbmc.log("=== MUBI STREAM ANALYSIS ===", xbmc.LOGINFO)
             xbmc.log(f"Complete stream_info received: {stream_info}", xbmc.LOGINFO)
 
             # Log available streams with detailed information
@@ -1330,7 +1323,7 @@ class Mubi:
                 if key not in ['urls', 'stream_url', 'license_key']:
                     xbmc.log(f"Additional stream metadata - {key}: {value}", xbmc.LOGINFO)
 
-            xbmc.log(f"=== END STREAM ANALYSIS ===", xbmc.LOGINFO)
+            xbmc.log("=== END STREAM ANALYSIS ===", xbmc.LOGINFO)
 
             # Prefer MPEG-DASH over HLS
             for stream in stream_info['urls']:

--- a/repo/plugin_video_mubi/resources/lib/navigation_handler.py
+++ b/repo/plugin_video_mubi/resources/lib/navigation_handler.py
@@ -23,14 +23,15 @@ class LibraryMonitor(xbmc.Monitor):
         self.scan_finished = False
 
     def onCleanFinished(self, library):
-        if library == 'video':
+        if library == "video":
             xbmc.log("Library clean finished.", xbmc.LOGDEBUG)
             self.clean_finished = True
 
     def onScanFinished(self, library):
-        if library == 'video':
+        if library == "video":
             xbmc.log("Library scan (update) finished.", xbmc.LOGDEBUG)
             self.scan_finished = True
+
 
 class NavigationHandler:
     """
@@ -59,7 +60,6 @@ class NavigationHandler:
         # Log the handle when NavigationHandler is initialized
         xbmc.log(f"NavigationHandler initialized with handle: {self.handle}", xbmc.LOGDEBUG)
 
-
     def get_url(self, **kwargs) -> str:
         """
         Create a plugin URL with the given keyword arguments.
@@ -74,12 +74,12 @@ class NavigationHandler:
         Build the main navigation menu presented to the user.
         """
         try:
-            self.session.is_logged_in = self.plugin.getSettingBool('logged') and self.session.token
+            self.session.is_logged_in = self.plugin.getSettingBool("logged") and self.session.token
             xbmcplugin.setPluginCategory(self.handle, "Mubi")
             xbmcplugin.setContent(self.handle, "videos")
 
             main_navigation_items = self._get_main_menu_items()
-            
+
             for item in main_navigation_items:
                 self._add_menu_item(item)
 
@@ -90,24 +90,29 @@ class NavigationHandler:
             xbmc.log(f"Error in main navigation: {e}", xbmc.LOGERROR)
 
     def _get_main_menu_items(self) -> list:
-        """ Helper method to retrieve main menu items based on login status. """
+        """Helper method to retrieve main menu items based on login status."""
         if self.session.is_logged_in:
             # Check fast sync setting
-            enable_fast_sync = self.plugin.getSettingBool('enable_fast_sync')
-            
+            enable_fast_sync = self.plugin.getSettingBool("enable_fast_sync")
+
             # Get client country for sync menu label
             sync_label, sync_description = self._get_sync_menu_label()
             worldwide_label, worldwide_description = self._get_sync_worldwide_menu_label()
-            
+
             # Base menu items
             menu_items = [
-                {"label": "Browse your Mubi watchlist", "description": "Browse your Mubi watchlist", "action": "watchlist", "is_folder": True}
+                {
+                    "label": "Browse your Mubi watchlist",
+                    "description": "Browse your Mubi watchlist",
+                    "action": "watchlist",
+                    "is_folder": True,
+                }
             ]
-            
+
             # Conditionally add sync options based on fast sync setting
             if enable_fast_sync:
                 # Fast sync enabled: show both local and worldwide options using GitHub
-                
+
                 # Local Sync (GitHub)
                 local_label = f"Sync {self._get_client_country_name()} catalogue"
                 local_desc = (
@@ -116,35 +121,62 @@ class NavigationHandler:
                 )
                 menu_items.append(
                     {
-                        "label": local_label, 
-                        "description": local_desc, 
-                        "action": "sync_github", 
+                        "label": local_label,
+                        "description": local_desc,
+                        "action": "sync_github",
                         "is_folder": False,
                         # Pass country as URL param handled in addon.py -> sync_from_github
-                        "params": {"country": self.plugin.getSetting("client_country")} 
+                        "params": {"country": self.plugin.getSetting("client_country")},
                     }
                 )
 
                 # Worldwide Sync (GitHub)
                 menu_items.append(
-                    {"label": "Sync worldwide catalogue", "description": worldwide_description, "action": "sync_github", "is_folder": False}
+                    {
+                        "label": "Sync worldwide catalogue",
+                        "description": worldwide_description,
+                        "action": "sync_github",
+                        "is_folder": False,
+                    }
                 )
             else:
                 # Fast sync disabled: show traditional MUBI sync options
-                menu_items.extend([
-                    {"label": sync_label, "description": sync_description, "action": "sync_locally", "is_folder": False},
-                    {"label": worldwide_label, "description": worldwide_description, "action": "sync_worldwide", "is_folder": False}
-                ])
-            
+                menu_items.extend(
+                    [
+                        {
+                            "label": sync_label,
+                            "description": sync_description,
+                            "action": "sync_locally",
+                            "is_folder": False,
+                        },
+                        {
+                            "label": worldwide_label,
+                            "description": worldwide_description,
+                            "action": "sync_worldwide",
+                            "is_folder": False,
+                        },
+                    ]
+                )
+
             # Add logout option
             menu_items.append(
-                {"label": "Log Out", "description": "Log out from your Mubi account", "action": "log_out", "is_folder": False}
+                {
+                    "label": "Log Out",
+                    "description": "Log out from your Mubi account",
+                    "action": "log_out",
+                    "is_folder": False,
+                }
             )
-            
+
             return menu_items
         else:
             return [
-                {"label": "Log In", "description": "Log in to your Mubi account", "action": "log_in", "is_folder": False}
+                {
+                    "label": "Log In",
+                    "description": "Log in to your Mubi account",
+                    "action": "log_in",
+                    "is_folder": False,
+                }
             ]
 
     def _get_sync_menu_label(self) -> tuple:
@@ -153,6 +185,7 @@ class NavigationHandler:
         Returns a tuple of (label, description with help info).
         """
         from .countries import COUNTRIES
+
         try:
             country_code = self.plugin.getSetting("client_country")
             if country_code:
@@ -180,6 +213,7 @@ class NavigationHandler:
         # Try to get coverage stats for a more informative label
         try:
             from .coverage_optimizer import get_coverage_stats
+
             country_code = self.plugin.getSetting("client_country") or "CH"
             stats = get_coverage_stats(country_code)
             if stats:
@@ -206,6 +240,7 @@ class NavigationHandler:
     def _get_client_country_name(self) -> str:
         """Get the client country name from settings."""
         from .countries import COUNTRIES
+
         try:
             country_code = self.plugin.getSetting("client_country")
             if country_code:
@@ -232,12 +267,7 @@ class NavigationHandler:
         )
 
         # yesno returns True if user clicks Yes, False if No
-        result = dialog.yesno(
-            "MUBI Sync",
-            message,
-            yeslabel="Start Sync",
-            nolabel="Cancel"
-        )
+        result = dialog.yesno("MUBI Sync", message, yeslabel="Start Sync", nolabel="Cancel")
 
         return result
 
@@ -253,14 +283,10 @@ class NavigationHandler:
                 url = self.get_url(action=item["action"], **item["params"])
             else:
                 url = self.get_url(action=item["action"])
-            
+
             xbmcplugin.addDirectoryItem(self.handle, url, list_item, item["is_folder"])
         except Exception as e:
             xbmc.log(f"Error adding menu item {item['label']}: {e}", xbmc.LOGERROR)
-
-
-
-
 
     def list_watchlist(self):
         """
@@ -281,8 +307,6 @@ class NavigationHandler:
         except Exception as e:
             xbmc.log(f"Error listing videos: {e}", xbmc.LOGERROR)
 
-
-
     def _add_film_item(self, film):
         try:
             list_item = xbmcgui.ListItem(label=film.title)
@@ -291,83 +315,85 @@ class NavigationHandler:
             # Set basic metadata
             info_tag.setTitle(film.title)
 
-            if hasattr(film.metadata, 'originaltitle') and film.metadata.originaltitle:
+            if hasattr(film.metadata, "originaltitle") and film.metadata.originaltitle:
                 info_tag.setOriginalTitle(film.metadata.originaltitle)
 
-            if hasattr(film.metadata, 'genre') and film.metadata.genre:
+            if hasattr(film.metadata, "genre") and film.metadata.genre:
                 genres = film.metadata.genre
                 if isinstance(genres, str):
                     genres = [genres]
                 info_tag.setGenres(genres)  # Expects a list
 
-            if hasattr(film.metadata, 'plot') and film.metadata.plot:
+            if hasattr(film.metadata, "plot") and film.metadata.plot:
                 info_tag.setPlot(film.metadata.plot)
 
-            if hasattr(film.metadata, 'year') and film.metadata.year:
+            if hasattr(film.metadata, "year") and film.metadata.year:
                 info_tag.setYear(int(film.metadata.year))
 
-            if hasattr(film.metadata, 'duration') and film.metadata.duration:
+            if hasattr(film.metadata, "duration") and film.metadata.duration:
                 info_tag.setDuration(int(film.metadata.duration))  # Duration in seconds
 
-            if hasattr(film.metadata, 'director') and film.metadata.director:
+            if hasattr(film.metadata, "director") and film.metadata.director:
                 directors = film.metadata.director
                 if isinstance(directors, str):
                     directors = [directors]
                 info_tag.setDirectors(directors)  # Expects a list
 
-            if hasattr(film.metadata, 'cast') and film.metadata.cast:
+            if hasattr(film.metadata, "cast") and film.metadata.cast:
                 info_tag.setCast(film.metadata.cast)  # Expects a list of dicts with 'name' keys
 
-            if hasattr(film.metadata, 'rating') and film.metadata.rating:
+            if hasattr(film.metadata, "rating") and film.metadata.rating:
                 info_tag.setRating(float(film.metadata.rating))
 
-            if hasattr(film.metadata, 'votes') and film.metadata.votes:
+            if hasattr(film.metadata, "votes") and film.metadata.votes:
                 info_tag.setVotes(int(film.metadata.votes))
 
-            if hasattr(film.metadata, 'imdb_id') and film.metadata.imdb_id:
-                info_tag.setUniqueID(film.metadata.imdb_id, 'imdb')
+            if hasattr(film.metadata, "imdb_id") and film.metadata.imdb_id:
+                info_tag.setUniqueID(film.metadata.imdb_id, "imdb")
 
             # Kodi 20+ (Nexus) features: Countries
-            if hasattr(film.metadata, 'country') and film.metadata.country:
+            if hasattr(film.metadata, "country") and film.metadata.country:
                 countries = film.metadata.country
                 if isinstance(countries, str):
                     countries = [countries]
                 info_tag.setCountries(countries)  # Expects a list
 
             # Kodi 20+ (Nexus) features: Premiered date (preferred over year)
-            if hasattr(film.metadata, 'premiered') and film.metadata.premiered:
+            if hasattr(film.metadata, "premiered") and film.metadata.premiered:
                 info_tag.setPremiered(film.metadata.premiered)
 
             # Kodi 20+ (Nexus) features: Content rating (MPAA)
-            if hasattr(film.metadata, 'mpaa') and film.metadata.mpaa:
+            if hasattr(film.metadata, "mpaa") and film.metadata.mpaa:
                 info_tag.setMpaa(film.metadata.mpaa)
 
             # Kodi 20+ (Nexus) features: Content warnings as tags
-            if hasattr(film.metadata, 'content_warnings') and film.metadata.content_warnings:
+            if hasattr(film.metadata, "content_warnings") and film.metadata.content_warnings:
                 tags = [str(w).strip() for w in film.metadata.content_warnings if w and str(w).strip()]
                 if tags:
                     info_tag.setTags(tags)
 
             # Kodi 20+ (Nexus) features: Press quote as tagline
-            if hasattr(film.metadata, 'tagline') and film.metadata.tagline:
+            if hasattr(film.metadata, "tagline") and film.metadata.tagline:
                 info_tag.setTagLine(film.metadata.tagline)
 
             # Kodi 20+ (Nexus) features: Audio and subtitle stream details
             self._add_stream_details(info_tag, film.metadata)
 
-            info_tag.setMediaType('movie')
+            info_tag.setMediaType("movie")
 
             # Set artwork
-            if hasattr(film.metadata, 'image') and film.metadata.image:
-                list_item.setArt({
-                    "thumb": film.metadata.image,
-                    "poster": film.metadata.image,
-                    "fanart": film.metadata.image,
-                    "landscape": film.metadata.image
-                })
+            if hasattr(film.metadata, "image") and film.metadata.image:
+                list_item.setArt(
+                    {
+                        "thumb": film.metadata.image,
+                        "poster": film.metadata.image,
+                        "fanart": film.metadata.image,
+                        "landscape": film.metadata.image,
+                    }
+                )
 
             # Set 'IsPlayable' property to inform Kodi this is a playable item
-            list_item.setProperty('IsPlayable', 'true')
+            list_item.setProperty("IsPlayable", "true")
 
             # Set the URL and path to the plugin URL
             url = self.get_url(action="play_mubi_video", film_id=film.mubi_id)
@@ -379,6 +405,7 @@ class NavigationHandler:
         except Exception as e:
             xbmc.log(f"Error adding film item {film.title}: {e}", xbmc.LOGERROR)
             import traceback
+
             xbmc.log(traceback.format_exc(), xbmc.LOGERROR)
 
     def _add_stream_details(self, info_tag, metadata):
@@ -389,47 +416,37 @@ class NavigationHandler:
         """
         try:
             # Add audio streams with language and channel information
-            if hasattr(metadata, 'audio_languages') and metadata.audio_languages:
-                audio_channels = getattr(metadata, 'audio_channels', [])
+            if hasattr(metadata, "audio_languages") and metadata.audio_languages:
+                audio_channels = getattr(metadata, "audio_channels", [])
                 for i, lang in enumerate(metadata.audio_languages):
                     if lang and str(lang).strip():
                         # Determine channel count from audio_channels if available
                         channels = 2  # Default to stereo
                         if i < len(audio_channels) and audio_channels[i]:
                             channel_str = str(audio_channels[i]).strip().lower()
-                            if channel_str == '5.1':
+                            if channel_str == "5.1":
                                 channels = 6
-                            elif channel_str == '7.1':
+                            elif channel_str == "7.1":
                                 channels = 8
-                            elif channel_str in ('stereo', '2.0'):
+                            elif channel_str in ("stereo", "2.0"):
                                 channels = 2
-                            elif channel_str in ('mono', '1.0'):
+                            elif channel_str in ("mono", "1.0"):
                                 channels = 1
 
                         # Create AudioStreamDetail (Kodi 20+)
-                        audio_stream = xbmc.AudioStreamDetail(
-                            channels=channels,
-                            language=str(lang).strip()
-                        )
+                        audio_stream = xbmc.AudioStreamDetail(channels=channels, language=str(lang).strip())
                         info_tag.addAudioStream(audio_stream)
 
             # Add subtitle streams with language information
-            if hasattr(metadata, 'subtitle_languages') and metadata.subtitle_languages:
+            if hasattr(metadata, "subtitle_languages") and metadata.subtitle_languages:
                 for lang in metadata.subtitle_languages:
                     if lang and str(lang).strip():
                         # Create SubtitleStreamDetail (Kodi 20+)
-                        subtitle_stream = xbmc.SubtitleStreamDetail(
-                            language=str(lang).strip()
-                        )
+                        subtitle_stream = xbmc.SubtitleStreamDetail(language=str(lang).strip())
                         info_tag.addSubtitleStream(subtitle_stream)
 
         except Exception as e:
             xbmc.log(f"Error adding stream details: {e}", xbmc.LOGDEBUG)
-
-
-
-
-
 
     def _is_safe_url(self, url: str) -> bool:
         """
@@ -445,7 +462,7 @@ class NavigationHandler:
             parsed = urlparse(url)
 
             # Check for valid scheme (http/https only)
-            if parsed.scheme not in ['http', 'https']:
+            if parsed.scheme not in ["http", "https"]:
                 xbmc.log(f"Unsafe URL scheme: {parsed.scheme}", xbmc.LOGWARNING)
                 return False
 
@@ -459,7 +476,7 @@ class NavigationHandler:
             netloc = parsed.netloc.lower() if parsed.netloc else ""
 
             # Check for dangerous characters in netloc (hostname:port)
-            dangerous_chars = [';', '|', '&', '`', '$']
+            dangerous_chars = [";", "|", "&", "`", "$"]
             # Note: Parentheses might appear in some valid URLs
             for char in dangerous_chars:
                 if char in netloc:
@@ -468,20 +485,32 @@ class NavigationHandler:
 
             if hostname:
                 hostname = hostname.lower()
-                if hostname in ['localhost', '127.0.0.1', '::1', '0.0.0.0', '[::]']:
+                if hostname in ["localhost", "127.0.0.1", "::1", "0.0.0.0", "[::]"]:
                     xbmc.log(f"Blocked localhost URL: {hostname}", xbmc.LOGWARNING)
                     return False
 
                 # Block private IP ranges and cloud metadata services
                 blocked_prefixes = [
-                    '192.168.',  # Private Class C
-                    '10.',       # Private Class A
-                    '172.16.', '172.17.', '172.18.', '172.19.',  # Private Class B
-                    '172.20.', '172.21.', '172.22.', '172.23.',
-                    '172.24.', '172.25.', '172.26.', '172.27.',
-                    '172.28.', '172.29.', '172.30.', '172.31.',
-                    '169.254.',  # Link-local (AWS/Azure metadata)
-                    '100.64.',   # Carrier-grade NAT
+                    "192.168.",  # Private Class C
+                    "10.",  # Private Class A
+                    "172.16.",
+                    "172.17.",
+                    "172.18.",
+                    "172.19.",  # Private Class B
+                    "172.20.",
+                    "172.21.",
+                    "172.22.",
+                    "172.23.",
+                    "172.24.",
+                    "172.25.",
+                    "172.26.",
+                    "172.27.",
+                    "172.28.",
+                    "172.29.",
+                    "172.30.",
+                    "172.31.",
+                    "169.254.",  # Link-local (AWS/Azure metadata)
+                    "100.64.",  # Carrier-grade NAT
                 ]
 
                 for prefix in blocked_prefixes:
@@ -491,7 +520,7 @@ class NavigationHandler:
 
             # Check for dangerous characters in URL path that could indicate injection
             if parsed.path:
-                dangerous_chars = [';', '|', '&', '`', '$']
+                dangerous_chars = [";", "|", "&", "`", "$"]
                 # Note: Parentheses are common in URLs and generally safe
                 for char in dangerous_chars:
                     if char in parsed.path:
@@ -517,20 +546,20 @@ class NavigationHandler:
             if not self._is_safe_url(web_url):
                 xbmcgui.Dialog().ok("MUBI", "Invalid or unsafe URL provided.")
                 return
-            
+
             import os
             import subprocess
-            
-            if xbmc.getCondVisibility('System.Platform.Windows'):
+
+            if xbmc.getCondVisibility("System.Platform.Windows"):
                 # Windows platform
                 os.startfile(web_url)
-            elif xbmc.getCondVisibility('System.Platform.OSX'):
+            elif xbmc.getCondVisibility("System.Platform.OSX"):
                 # macOS platform
-                subprocess.Popen(['open', web_url], shell=False)
-            elif xbmc.getCondVisibility('System.Platform.Linux'):
+                subprocess.Popen(["open", web_url], shell=False)
+            elif xbmc.getCondVisibility("System.Platform.Linux"):
                 # Linux platform
-                subprocess.Popen(['xdg-open', web_url], shell=False)
-            elif xbmc.getCondVisibility('System.Platform.Android'):
+                subprocess.Popen(["xdg-open", web_url], shell=False)
+            elif xbmc.getCondVisibility("System.Platform.Android"):
                 # Android platform
                 xbmc.executebuiltin(f'StartAndroidActivity("", "", "android.intent.action.VIEW", "{web_url}")')
             else:
@@ -539,8 +568,6 @@ class NavigationHandler:
         except Exception as e:
             xbmc.log(f"Error opening external video: {e}", xbmc.LOGERROR)
             xbmcgui.Dialog().ok("MUBI", f"Error opening external video: {e}")
-
-
 
     def _get_available_countries_data_from_nfo(self, film_id: str) -> dict:
         """
@@ -573,31 +600,31 @@ class NavigationHandler:
                 # Helper to extract availability dict from availability element
                 def extract_availability(mubi_availability_node) -> dict:
                     if mubi_availability_node is None:
-                         return {}
-                    
+                        return {}
+
                     data = {}
                     for country in mubi_availability_node.findall("country"):
                         code = country.get("code")
                         if not code:
-                             continue
-                        
+                            continue
+
                         details = {}
                         # Extract availability status
                         avail_node = country.find("availability")
                         if avail_node is not None and avail_node.text:
-                            details['availability'] = avail_node.text
+                            details["availability"] = avail_node.text
                         else:
-                            details['availability'] = 'live' # Default if missing but country present
-                        
+                            details["availability"] = "live"  # Default if missing but country present
+
                         # Extract other fields if needed
-                        for field in ['available_at', 'expires_at', 'availability_ends_at']:
+                        for field in ["available_at", "expires_at", "availability_ends_at"]:
                             node = country.find(field)
                             if node is not None and node.text:
                                 details[field] = node.text
-                        
+
                         data[code] = details
                     return data
-                
+
                 # Check if this NFO matches the film_id (look for the STRM file or film ID)
                 uniqueid = root.find(".//uniqueid[@type='mubi']")
                 if uniqueid is not None and uniqueid.text == film_id:
@@ -649,25 +676,21 @@ class NavigationHandler:
         from .countries import COUNTRIES
 
         suggestions = []
-        
+
         # Handle if list is passed (legacy fallback)
         if isinstance(available_countries_data, list):
-             available_countries_data = {c: {'availability': 'live'} for c in available_countries_data}
+            available_countries_data = {c: {"availability": "live"} for c in available_countries_data}
 
         for code, details in available_countries_data.items():
             code_lower = code.lower()
-            
+
             # Filter: must be currently available (date check or 'live' status)
             if not self._is_country_available(details):
                 continue
 
             if code_lower in COUNTRIES:
                 country_data = COUNTRIES[code_lower]
-                suggestions.append((
-                    code.upper(),
-                    country_data["name"],
-                    country_data.get("vpn_tier", 4)
-                ))
+                suggestions.append((code.upper(), country_data["name"], country_data.get("vpn_tier", 4)))
 
         # Sort by VPN tier (lower is better), then alphabetically by name
         suggestions.sort(key=lambda x: (x[2], x[1]))
@@ -728,10 +751,7 @@ class NavigationHandler:
                     f"Already connected?"
                 )
             else:
-                message = (
-                    f"This movie is not available in {client_country_name}.\n\n"
-                    f"Connect to a VPN and try again."
-                )
+                message = f"This movie is not available in {client_country_name}.\n\nConnect to a VPN and try again."
                 # No VPN suggestions — just inform, no play option
                 xbmcgui.Dialog().ok("MUBI - Not Available", message)
                 xbmcplugin.setResolvedUrl(self.handle, False, xbmcgui.ListItem())
@@ -740,12 +760,7 @@ class NavigationHandler:
             xbmc.log(f"Film not available in {client_country}: showing VPN dialog", xbmc.LOGINFO)
 
             # yesno: Yes = "I'm connected, play!" / No = "Cancel"
-            should_play = xbmcgui.Dialog().yesno(
-                "MUBI - Not Available",
-                message,
-                yeslabel="Play",
-                nolabel="Cancel"
-            )
+            should_play = xbmcgui.Dialog().yesno("MUBI - Not Available", message, yeslabel="Play", nolabel="Cancel")
 
             if not should_play:
                 xbmcplugin.setResolvedUrl(self.handle, False, xbmcgui.ListItem())
@@ -754,13 +769,10 @@ class NavigationHandler:
             # Country is in the list — check if it's actually live (not upcoming/expired)
             details = available_countries_data.get(client_country, {})
             if not self._is_country_available(details):
-                availability_status = details.get('availability', 'unknown')
+                availability_status = details.get("availability", "unknown")
                 xbmc.log(f"Film {film_id} in {client_country} status: {availability_status}", xbmc.LOGINFO)
 
-                message = (
-                    f"This movie is currently {availability_status} in your country.\n\n"
-                    f"Play anyway?"
-                )
+                message = f"This movie is currently {availability_status} in your country.\n\nPlay anyway?"
                 if not xbmcgui.Dialog().yesno("MUBI - Availability Warning", message):
                     xbmcplugin.setResolvedUrl(self.handle, False, xbmcgui.ListItem())
                     return
@@ -770,8 +782,8 @@ class NavigationHandler:
             stream_info = self.mubi.get_secure_stream_info(film_id)
             xbmc.log(f"Stream info for film_id {film_id}: {stream_info}", xbmc.LOGDEBUG)
 
-            if 'error' in stream_info:
-                error_msg = stream_info['error']
+            if "error" in stream_info:
+                error_msg = stream_info["error"]
                 xbmc.log(f"Error in stream info: {error_msg}", xbmc.LOGERROR)
                 xbmcgui.Dialog().notification("MUBI", f"Error: {error_msg}", xbmcgui.NOTIFICATION_ERROR)
                 xbmcplugin.setResolvedUrl(self.handle, False, xbmcgui.ListItem())
@@ -787,21 +799,30 @@ class NavigationHandler:
                 raise Exception("No suitable stream found")
 
             # Extract subtitle tracks
-            subtitles = stream_info.get('text_track_urls', [])
+            subtitles = stream_info.get("text_track_urls", [])
             xbmc.log(f"Available subtitles: {subtitles}", xbmc.LOGDEBUG)
 
             # Play video using InputStream Adaptive
-            xbmc.log(f"Calling play_with_inputstream_adaptive with handle: {self.handle}, stream URL: {best_stream_url}", xbmc.LOGDEBUG)
-            play_with_inputstream_adaptive(self.handle, best_stream_url, stream_info['license_key'], subtitles,
-                                         self.session.token, self.session.user_id)
+            xbmc.log(
+                f"Calling play_with_inputstream_adaptive with handle: {self.handle}, stream URL: {best_stream_url}",
+                xbmc.LOGDEBUG,
+            )
+            play_with_inputstream_adaptive(
+                self.handle,
+                best_stream_url,
+                stream_info["license_key"],
+                subtitles,
+                self.session.token,
+                self.session.user_id,
+            )
 
         except requests.RequestException as e:
             xbmc.log(f"Network error playing Mubi video: {e}", xbmc.LOGERROR)
             xbmcgui.Dialog().notification("MUBI", f"Network Error: {str(e)}", xbmcgui.NOTIFICATION_ERROR)
 
             if web_url:
-                 if xbmcgui.Dialog().yesno("MUBI", "Network error. Try opening in web browser?"):
-                     self.play_video_ext(web_url)
+                if xbmcgui.Dialog().yesno("MUBI", "Network error. Try opening in web browser?"):
+                    self.play_video_ext(web_url)
 
         except Exception as e:
             xbmc.log(f"Error playing Mubi video: {e}", xbmc.LOGERROR)
@@ -814,11 +835,9 @@ class NavigationHandler:
                 if xbmcgui.Dialog().yesno("MUBI", "Failed to play the video. Do you want to open it in a web browser?"):
                     self.play_video_ext(web_url)
             else:
-                xbmcgui.Dialog().notification("MUBI", "Unable to open in web browser. Web URL is missing.", xbmcgui.NOTIFICATION_ERROR)
-
-
-
-
+                xbmcgui.Dialog().notification(
+                    "MUBI", "Unable to open in web browser. Web URL is missing.", xbmcgui.NOTIFICATION_ERROR
+                )
 
     def _resolve_trailer_url(self, url: str) -> str:
         """
@@ -842,7 +861,7 @@ class NavigationHandler:
             # Only validate HTTP(S) links
             if not url.startswith("http"):
                 return True
-                
+
             response = requests.head(url, timeout=5, allow_redirects=True)
             return response.status_code < 400
         except requests.RequestException:
@@ -857,7 +876,7 @@ class NavigationHandler:
         try:
             # 1. Resolve YouTube URLs
             resolved_url = self._resolve_trailer_url(url)
-            
+
             # 2. If it's a web URL (not a plugin:// URL), validate it
             # We skip validation for plugin:// URLs as they are handled by other addons
             if resolved_url.startswith("http"):
@@ -865,12 +884,7 @@ class NavigationHandler:
                 if not is_valid:
                     xbmc.log(f"Trailer URL is unreachable: {resolved_url}", xbmc.LOGWARNING)
                     dialog = xbmcgui.Dialog()
-                    dialog.notification(
-                        "MUBI",
-                        "Trailer unavailable",
-                        xbmcgui.NOTIFICATION_ERROR,
-                        3000
-                    )
+                    dialog.notification("MUBI", "Trailer unavailable", xbmcgui.NOTIFICATION_ERROR, 3000)
                     # We still set resolved URL to false to tell Kodi we failed
                     xbmcplugin.setResolvedUrl(self.handle, False, listitem=xbmcgui.ListItem())
                     return
@@ -883,42 +897,42 @@ class NavigationHandler:
             # Ensure we don't leave Kodi hanging
             xbmcplugin.setResolvedUrl(self.handle, False, listitem=xbmcgui.ListItem())
 
-
-
     def log_in(self):
         """
         Handle user login by generating a link code and authenticating with Mubi.
         """
         try:
             code_info = self.mubi.get_link_code()
-            if 'auth_token' in code_info and 'link_code' in code_info:
+            if "auth_token" in code_info and "link_code" in code_info:
                 self._display_login_code(code_info)
-                auth_response = self.mubi.authenticate(code_info['auth_token'])
+                auth_response = self.mubi.authenticate(code_info["auth_token"])
 
-                if auth_response and 'token' in auth_response:
+                if auth_response and "token" in auth_response:
                     # Token and user ID are already set in session inside authenticate method
                     xbmcgui.Dialog().notification("MUBI", "Successfully logged in!", xbmcgui.NOTIFICATION_INFO)
-                    xbmc.executebuiltin('Container.Refresh')
+                    xbmc.executebuiltin("Container.Refresh")
                 else:
                     self._handle_login_error(auth_response)
             else:
-                xbmcgui.Dialog().notification('MUBI', 'Error during code generation.', xbmcgui.NOTIFICATION_ERROR)
+                xbmcgui.Dialog().notification("MUBI", "Error during code generation.", xbmcgui.NOTIFICATION_ERROR)
 
         except Exception as e:
             xbmc.log(f"Exception during login: {e}", xbmc.LOGERROR)
-            xbmcgui.Dialog().notification('MUBI', 'An unexpected error occurred during login.', xbmcgui.NOTIFICATION_ERROR)
-
-
+            xbmcgui.Dialog().notification(
+                "MUBI", "An unexpected error occurred during login.", xbmcgui.NOTIFICATION_ERROR
+            )
 
     def _display_login_code(self, code_info: dict):
-        """ Helper method to display login code to the user """
-        link_code = code_info['link_code']
-        xbmcgui.Dialog().ok("Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]{MUBI_LOGIN_ACTIVATION_URL}[/B]")
+        """Helper method to display login code to the user"""
+        link_code = code_info["link_code"]
+        xbmcgui.Dialog().ok(
+            "Log In", f"Enter code [COLOR=yellow][B]{link_code}[/B][/COLOR] on [B]{MUBI_LOGIN_ACTIVATION_URL}[/B]"
+        )
 
     def _handle_login_error(self, auth_response: dict):
-        """ Handle login errors from the Mubi API """
-        error_message = auth_response.get('message', 'Unknown error')
-        xbmcgui.Dialog().notification('MUBI', f"Error: {error_message}", xbmcgui.NOTIFICATION_ERROR)
+        """Handle login errors from the Mubi API"""
+        error_message = auth_response.get("message", "Unknown error")
+        xbmcgui.Dialog().notification("MUBI", f"Error: {error_message}", xbmcgui.NOTIFICATION_ERROR)
 
     def log_out(self):
         """
@@ -929,13 +943,13 @@ class NavigationHandler:
             if success:
                 self.session.set_logged_out()
                 xbmcgui.Dialog().notification("MUBI", "Successfully logged out!", xbmcgui.NOTIFICATION_INFO)
-                xbmc.executebuiltin('Container.Refresh')
+                xbmc.executebuiltin("Container.Refresh")
             else:
-                xbmcgui.Dialog().notification('MUBI', 'Error during logout. You are still logged in.', xbmcgui.NOTIFICATION_ERROR)
+                xbmcgui.Dialog().notification(
+                    "MUBI", "Error during logout. You are still logged in.", xbmcgui.NOTIFICATION_ERROR
+                )
         except Exception as e:
             xbmc.log(f"Error during logout: {e}", xbmc.LOGERROR)
-
-
 
     def sync_films(self, countries: list, dialog_title: Optional[str] = None):
         """
@@ -947,6 +961,7 @@ class NavigationHandler:
             return
 
         from .countries import COUNTRIES
+
         # Determine dialog title
         if dialog_title is None:
             num_countries = len(countries)
@@ -962,24 +977,27 @@ class NavigationHandler:
     def sync_from_github(self, country: str = None):
         """
         Sync MUBI films locally by downloading a pre-computed database from GitHub.
-        
+
         :param country: Optional ISO 3166-1 alpha-2 country code to filter by.
         """
         from .data_source import GithubDataSource
+
         github_source = GithubDataSource()
-        
+
         countries = [country.upper()] if country else None
         title = f"Syncing ({country.upper() if country else 'Worldwide'})..."
-        
+
         # Skip external metadata checks/fetches for GitHub sync as the JSON is already enriched
         self._perform_sync(
-            dialog_title=title, 
-            data_source=github_source, 
+            dialog_title=title,
+            data_source=github_source,
             skip_external_metadata=True,
-            countries=countries # Pass filter to data source
+            countries=countries,  # Pass filter to data source
         )
 
-    def _perform_sync(self, dialog_title: str, countries: list = None, data_source=None, skip_external_metadata: bool = False):
+    def _perform_sync(
+        self, dialog_title: str, countries: list = None, data_source=None, skip_external_metadata: bool = False
+    ):
         """
         Helper method to execute the common sync logic (locking, provider check, fetching, library update).
         """
@@ -990,10 +1008,7 @@ class NavigationHandler:
         with NavigationHandler._sync_lock:
             if NavigationHandler._sync_in_progress:
                 xbmcgui.Dialog().notification(
-                    "MUBI",
-                    "Sync already in progress. Please wait for it to complete.",
-                    xbmcgui.NOTIFICATION_INFO,
-                    5000
+                    "MUBI", "Sync already in progress. Please wait for it to complete.", xbmcgui.NOTIFICATION_INFO, 5000
                 )
                 xbmc.log("Sync operation blocked - another sync already in progress", xbmc.LOGINFO)
                 return
@@ -1004,7 +1019,7 @@ class NavigationHandler:
             # Check if metadata providers are configured, unless skipping
             if not skip_external_metadata:
                 provider = MetadataProviderFactory.get_provider()
-                
+
                 if not provider:
                     dialog = xbmcgui.Dialog()
                     ret = dialog.yesno(
@@ -1013,22 +1028,23 @@ class NavigationHandler:
                         "you need to configure an external metadata provider.\n\n"
                         "Please execute the Settings to configure TMDB (free) or OMDb API key.",
                         yeslabel="Go to Settings",
-                        nolabel="Cancel"
+                        nolabel="Cancel",
                     )
 
                     if ret:
                         MetadataProviderFactory.open_settings()
                         provider = MetadataProviderFactory.get_provider()
-                        if not provider: return
+                        if not provider:
+                            return
                     else:
                         return
 
                 if not provider.test_connection():
                     xbmcgui.Dialog().notification(
-                        "MUBI", 
-                        f"Invalid API Key for {provider.provider_name}. Sync aborted.", 
+                        "MUBI",
+                        f"Invalid API Key for {provider.provider_name}. Sync aborted.",
                         xbmcgui.NOTIFICATION_ERROR,
-                        5000
+                        5000,
                     )
                     xbmc.log(f"Sync aborted: Invalid API key for {provider.provider_name}", xbmc.LOGERROR)
                     return
@@ -1056,7 +1072,7 @@ class NavigationHandler:
                     message = f"Fetching films from {country_name}...\n{current_films} films found"
                 else:
                     # GitHub sync (no total countries usually, or treated differently)
-                    percent = 50 # Indeterminate or based on generic progress
+                    percent = 50  # Indeterminate or based on generic progress
                     message = "Fetching database..."
 
                 pDialog.update(percent, message)
@@ -1067,39 +1083,35 @@ class NavigationHandler:
                     playable_only=True,
                     progress_callback=update_fetch_progress,
                     countries=countries,
-                    data_source=data_source
+                    data_source=data_source,
                 )
             except (ValueError, Exception) as e:
                 # Handle specific known errors (ValueError might be MD5 or validation)
                 msg = str(e)
-                
+
                 # Check for cancellation first (raised as general Exception sometimes)
                 if "canceled" in msg.lower():
                     pDialog.close()
                     xbmc.log("User canceled the sync process during film fetching.", xbmc.LOGDEBUG)
                     return None
-                
+
                 # Identify error type for cleaner notification
                 if "MD5" in msg:
                     error_body = "Download integrity check failed."
                 elif "JSON" in msg or "parsing" in msg.lower():
                     error_body = "Data format error from server."
                 elif "HTTP" in msg or "Connection" in msg or "Max retries" in msg:
-                        error_body = "Network error or server unavailable."
+                    error_body = "Network error or server unavailable."
                 else:
-                        error_body = f"Error: {msg}"
+                    error_body = f"Error: {msg}"
 
                 import traceback
+
                 xbmc.log(f"Sync failed with error: {e}", xbmc.LOGERROR)
                 xbmc.log(f"Full traceback:\n{traceback.format_exc()}", xbmc.LOGERROR)
                 pDialog.close()
-                
-                xbmcgui.Dialog().notification(
-                    "MUBI", 
-                    error_body,
-                    xbmcgui.NOTIFICATION_ERROR,
-                    5000
-                )
+
+                xbmcgui.Dialog().notification("MUBI", error_body, xbmcgui.NOTIFICATION_ERROR, 5000)
                 return None
 
             # Update progress dialog for file creation phase
@@ -1114,9 +1126,10 @@ class NavigationHandler:
 
             plugin_userdata_path = Path(xbmcvfs.translatePath(self.plugin.getAddonInfo("profile")))
             pDialog.close()
-            
+
             # Small delay
             import time
+
             time.sleep(0.1)
 
             # Sync files locally
@@ -1129,14 +1142,17 @@ class NavigationHandler:
             if self.plugin.getSettingBool("auto_clean_library"):
                 self.clean_kodi_library(monitor)
             else:
-                    xbmc.log("Library cleaning disabled by setting", xbmc.LOGDEBUG)
+                xbmc.log("Library cleaning disabled by setting", xbmc.LOGDEBUG)
             self.update_kodi_library()
 
         except Exception as e:
             xbmc.log(f"Error during sync: {e}", xbmc.LOGERROR)
             import traceback
+
             xbmc.log(traceback.format_exc(), xbmc.LOGERROR)
-            xbmcgui.Dialog().notification("MUBI", "An unexpected error occurred during sync.", xbmcgui.NOTIFICATION_ERROR)
+            xbmcgui.Dialog().notification(
+                "MUBI", "An unexpected error occurred during sync.", xbmcgui.NOTIFICATION_ERROR
+            )
         finally:
             with NavigationHandler._sync_lock:
                 NavigationHandler._sync_in_progress = False
@@ -1145,24 +1161,25 @@ class NavigationHandler:
     def wait_for_library_idle(self, timeout=30):
         """
         Wait until the Kodi library is idle (not scanning or cleaning).
-        
+
         :param timeout: Maximum time to wait in seconds.
         """
         import time
+
         start_time = time.time()
         while time.time() - start_time < timeout:
             if xbmc.abortRequested:
                 break
-                
-            is_scanning = xbmc.getCondVisibility('Library.IsScanningVideo')
-            is_cleaning = xbmc.getCondVisibility('Library.IsCleaning')
-            
+
+            is_scanning = xbmc.getCondVisibility("Library.IsScanningVideo")
+            is_cleaning = xbmc.getCondVisibility("Library.IsCleaning")
+
             if not is_scanning and not is_cleaning:
                 return
-            
+
             xbmc.log("Waiting for library to become idle...", xbmc.LOGDEBUG)
             time.sleep(1)
-            
+
         xbmc.log("Timeout waiting for library to become idle. Proceeding anyway.", xbmc.LOGWARNING)
 
     def update_kodi_library(self):
@@ -1173,11 +1190,10 @@ class NavigationHandler:
         try:
             self.wait_for_library_idle()
             xbmc.log("Triggering Kodi library update...", xbmc.LOGDEBUG)
-            xbmc.executebuiltin('UpdateLibrary(video)')
+            xbmc.executebuiltin("UpdateLibrary(video)")
             xbmc.log("Library update triggered successfully - running in background", xbmc.LOGDEBUG)
         except Exception as e:
             xbmc.log(f"Error triggering Kodi library update: {e}", xbmc.LOGERROR)
-
 
     def clean_kodi_library(self, monitor):
         """
@@ -1187,7 +1203,7 @@ class NavigationHandler:
         try:
             self.wait_for_library_idle()
             xbmc.log("Triggering Kodi library clean...", xbmc.LOGDEBUG)
-            xbmc.executebuiltin('CleanLibrary(video)')
+            xbmc.executebuiltin("CleanLibrary(video)")
 
             # Wait for the clean operation to finish
             xbmc.log("Waiting for library clean to complete...", xbmc.LOGDEBUG)
@@ -1198,4 +1214,3 @@ class NavigationHandler:
             xbmc.log("Library clean completed", xbmc.LOGDEBUG)
         except Exception as e:
             xbmc.log(f"Error triggering Kodi library clean: {e}", xbmc.LOGERROR)
-

--- a/repo/plugin_video_mubi/resources/lib/navigation_handler.py
+++ b/repo/plugin_video_mubi/resources/lib/navigation_handler.py
@@ -1,20 +1,20 @@
-import xbmcgui
-import xbmcplugin
+import re
+import threading
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlencode
+
+import requests
 import xbmc
 import xbmcaddon
-import webbrowser
-from urllib.parse import urlencode
+import xbmcgui
+import xbmcplugin
 import xbmcvfs
-from pathlib import Path
-import threading
-from typing import Optional
-from .library import Library
-from .library import Library
-from .playback import play_with_inputstream_adaptive
-from .constants import MUBI_LOGIN_ACTIVATION_URL
+
 from .availability import is_country_available
-import requests
-import re
+from .constants import MUBI_LOGIN_ACTIVATION_URL
+from .playback import play_with_inputstream_adaptive
+
 
 class LibraryMonitor(xbmc.Monitor):
     def __init__(self):
@@ -183,13 +183,11 @@ class NavigationHandler:
             country_code = self.plugin.getSetting("client_country") or "CH"
             stats = get_coverage_stats(country_code)
             if stats:
-                optimal_count = stats.get('optimal_country_count', 0)
-                total_films = stats.get('total_films', 0)
-                label = f"Sync MUBI worldwide (about 2k films)"
+                label = "Sync MUBI worldwide (about 2k films)"
                 description = (
-                    f"Sync all films from MUBI's worldwide catalogue.\n\n"
-                    f"No VPN needed to sync, but a VPN is required to play "
-                    f"movies outside of your country."
+                    "Sync all films from MUBI's worldwide catalogue.\n\n"
+                    "No VPN needed to sync, but a VPN is required to play "
+                    "movies outside of your country."
                 )
                 return label, description
         except Exception:
@@ -520,8 +518,8 @@ class NavigationHandler:
                 xbmcgui.Dialog().ok("MUBI", "Invalid or unsafe URL provided.")
                 return
             
-            import subprocess
             import os
+            import subprocess
             
             if xbmc.getCondVisibility('System.Platform.Windows'):
                 # Windows platform
@@ -551,8 +549,8 @@ class NavigationHandler:
         :param film_id: The MUBI film ID.
         :return: Dict {country_code: {'availability': 'live', ...}}
         """
-        import xml.etree.ElementTree as ET
         import re
+        import xml.etree.ElementTree as ET
         from pathlib import Path
 
         plugin_userdata_path = Path(xbmcvfs.translatePath(self.plugin.getAddonInfo("profile")))
@@ -697,9 +695,8 @@ class NavigationHandler:
         """
         import xbmc
         import xbmcgui
-        import xbmcaddon
+
         from .countries import COUNTRIES
-        from .playback import play_with_inputstream_adaptive
 
         if not film_id:
             xbmc.log("play_mubi_video: No film_id provided", xbmc.LOGERROR)
@@ -986,8 +983,8 @@ class NavigationHandler:
         """
         Helper method to execute the common sync logic (locking, provider check, fetching, library update).
         """
-        from .external_metadata import MetadataProviderFactory
         from .countries import COUNTRIES
+        from .external_metadata import MetadataProviderFactory
 
         # BUG #7 FIX: Check if sync is already in progress
         with NavigationHandler._sync_lock:
@@ -1060,7 +1057,7 @@ class NavigationHandler:
                 else:
                     # GitHub sync (no total countries usually, or treated differently)
                     percent = 50 # Indeterminate or based on generic progress
-                    message = f"Fetching database..."
+                    message = "Fetching database..."
 
                 pDialog.update(percent, message)
 
@@ -1083,7 +1080,6 @@ class NavigationHandler:
                     return None
                 
                 # Identify error type for cleaner notification
-                error_title = "Sync Failed"
                 if "MD5" in msg:
                     error_body = "Download integrity check failed."
                 elif "JSON" in msg or "parsing" in msg.lower():

--- a/repo/plugin_video_mubi/resources/lib/playback.py
+++ b/repo/plugin_video_mubi/resources/lib/playback.py
@@ -25,11 +25,11 @@ def generate_drm_license_key(token, user_id):
     dcd_enc = base64.b64encode(dcd.encode()).decode()
 
     drm_headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-        'dt-custom-data': dcd_enc,
-        'Referer': f'{MUBI_WEB_URL}/',
-        'Origin': MUBI_WEB_URL,
-        'Content-Type': ''
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
+        "dt-custom-data": dcd_enc,
+        "Referer": f"{MUBI_WEB_URL}/",
+        "Origin": MUBI_WEB_URL,
+        "Content-Type": "",
     }
 
     # Build the full DRM license key URL using the headers
@@ -50,11 +50,11 @@ def generate_drm_config(token, user_id):
     dcd_enc = base64.b64encode(dcd.encode()).decode()
 
     drm_headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-        'dt-custom-data': dcd_enc,
-        'Referer': f'{MUBI_WEB_URL}/',
-        'Origin': MUBI_WEB_URL,
-        'Content-Type': ''
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
+        "dt-custom-data": dcd_enc,
+        "Referer": f"{MUBI_WEB_URL}/",
+        "Origin": MUBI_WEB_URL,
+        "Content-Type": "",
     }
 
     drm_config = {
@@ -71,8 +71,9 @@ def generate_drm_config(token, user_id):
     return drm_config
 
 
-def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, subtitles: list,
-                                   token: str = None, user_id: str = None):
+def play_with_inputstream_adaptive(
+    handle, stream_url: str, license_key: str, subtitles: list, token: str = None, user_id: str = None
+):
     """
     Plays a video using InputStream Adaptive (ISA) with DRM protection and subtitles.
     Supports both legacy (Kodi < 22) and new (Kodi >= 22) DRM configuration formats.
@@ -87,30 +88,30 @@ def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, su
     try:
         # Determine the streaming protocol from the URL
         from urllib.parse import urlparse
+
         path = urlparse(stream_url).path
-        
-        if path.endswith('.mpd'):
+
+        if path.endswith(".mpd"):
             protocol = "mpd"  # MPEG-DASH
-            mime_type = 'application/dash+xml'
-        elif path.endswith('.m3u8'):
+            mime_type = "application/dash+xml"
+        elif path.endswith(".m3u8"):
             protocol = "hls"  # HLS
-            mime_type = 'application/vnd.apple.mpegurl'
+            mime_type = "application/vnd.apple.mpegurl"
         else:
             raise ValueError(f"Unsupported stream format in URL: {stream_url}")
 
         drm_type = "com.widevine.alpha"  # Widevine DRM
 
         # Log the protocol and stream details for debugging
-        xbmc.log(f"Selected protocol: {protocol}, MIME type: {mime_type}, Stream URL: {stream_url}",
-                 xbmc.LOGDEBUG)
+        xbmc.log(f"Selected protocol: {protocol}, MIME type: {mime_type}, Stream URL: {stream_url}", xbmc.LOGDEBUG)
 
         is_helper = inputstreamhelper.Helper(protocol, drm=drm_type)
 
         # Set the headers that will be used for the license and manifest
         stream_headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
-            'Referer': f'{MUBI_WEB_URL}/',
-            'Origin': MUBI_WEB_URL
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
+            "Referer": f"{MUBI_WEB_URL}/",
+            "Origin": MUBI_WEB_URL,
         }
 
         headers_str = "&".join([f"{k}={v}" for k, v in stream_headers.items()])
@@ -123,22 +124,24 @@ def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, su
                 patcher = MPDPatcher()
                 # We need to pass headers for the download
                 patched_path = patcher.patch(stream_url, stream_headers)
-                
+
                 if patched_path:
                     # Use Local HTTP Server to serve the patched manifest
                     # This bypasses inputstream.adaptive's issues with local files on some platforms
                     server = LocalServer.get_instance()
                     local_url = server.get_url(patched_path)
-                    
+
                     # Verify LocalServer is actually working before using it
                     # This catches issues like the Linux ABI mismatch crash early
                     if server.is_healthy():
-                        xbmc.log(f"Using patched manifest via local server: {local_url} (file: {patched_path})", xbmc.LOGINFO)
+                        xbmc.log(
+                            f"Using patched manifest via local server: {local_url} (file: {patched_path})", xbmc.LOGINFO
+                        )
                         stream_url = local_url
                     else:
                         xbmc.log("LocalServer health check failed, using original URL", xbmc.LOGWARNING)
-                    
-                    # We MUST pass headers even for local playback, because the segments 
+
+                    # We MUST pass headers even for local playback, because the segments
                     # are still fetched from the remote CDN and require authentication.
                     # The LocalServer (SimpleHTTPRequestHandler) will safely ignore these headers.
             except Exception as e:
@@ -148,38 +151,37 @@ def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, su
             play_item = xbmcgui.ListItem(path=stream_url)
             play_item.setMimeType(mime_type)
             play_item.setContentLookup(False)
-            play_item.setProperty('inputstream', is_helper.inputstream_addon)
+            play_item.setProperty("inputstream", is_helper.inputstream_addon)
             play_item.setProperty("IsPlayable", "true")
-            play_item.setProperty('inputstream.adaptive.stream_headers', headers_str)
-            play_item.setProperty('inputstream.adaptive.manifest_headers', headers_str)
-            play_item.setProperty('inputstream.adaptive.manifest_type', protocol)
+            play_item.setProperty("inputstream.adaptive.stream_headers", headers_str)
+            play_item.setProperty("inputstream.adaptive.manifest_headers", headers_str)
+            play_item.setProperty("inputstream.adaptive.manifest_type", protocol)
 
             # Kodi version detection for DRM configuration
-            kodi_version = xbmc.getInfoLabel('System.BuildVersion')
-            kodi_major_version = int(kodi_version.split('.')[0])
+            kodi_version = xbmc.getInfoLabel("System.BuildVersion")
+            kodi_major_version = int(kodi_version.split(".")[0])
 
-            xbmc.log(f"Detected Kodi version: {kodi_version}, major version: {kodi_major_version}",
-                     xbmc.LOGDEBUG)
+            xbmc.log(f"Detected Kodi version: {kodi_version}, major version: {kodi_major_version}", xbmc.LOGDEBUG)
 
             if kodi_major_version < 22:
                 # Legacy DRM configuration for Kodi < 22
                 xbmc.log("Using legacy DRM configuration for Kodi < 22", xbmc.LOGDEBUG)
-                play_item.setProperty('inputstream.adaptive.license_type', drm_type)
-                play_item.setProperty('inputstream.adaptive.license_key', license_key)
+                play_item.setProperty("inputstream.adaptive.license_type", drm_type)
+                play_item.setProperty("inputstream.adaptive.license_key", license_key)
             else:
                 # New DRM configuration for Kodi >= 22 (ISA v22.1.5+)
                 xbmc.log("Using new DRM configuration for Kodi >= 22", xbmc.LOGDEBUG)
                 if token and user_id:
                     drm_config = generate_drm_config(token, user_id)
-                    play_item.setProperty('inputstream.adaptive.drm', json.dumps(drm_config))
+                    play_item.setProperty("inputstream.adaptive.drm", json.dumps(drm_config))
                 else:
                     # Fallback to legacy if token/user_id not provided
                     xbmc.log("Token/user_id not provided, falling back to legacy DRM", xbmc.LOGWARNING)
-                    play_item.setProperty('inputstream.adaptive.license_type', drm_type)
-                    play_item.setProperty('inputstream.adaptive.license_key', license_key)
+                    play_item.setProperty("inputstream.adaptive.license_type", drm_type)
+                    play_item.setProperty("inputstream.adaptive.license_key", license_key)
 
             # Add subtitles to the ListItem
-            subtitle_urls = [subtitle['url'] for subtitle in subtitles]
+            subtitle_urls = [subtitle["url"] for subtitle in subtitles]
             play_item.setSubtitles(subtitle_urls)
             xbmc.log(f"Subtitles added: {subtitle_urls}", xbmc.LOGDEBUG)
 
@@ -200,5 +202,6 @@ def play_with_inputstream_adaptive(handle, stream_url: str, license_key: str, su
         xbmcgui.Dialog().notification("MUBI", f"Error: {ve}", xbmcgui.NOTIFICATION_ERROR)
     except Exception as e:
         xbmc.log(f"Error initializing InputStream Adaptive: {e}", xbmc.LOGERROR)
-        xbmcgui.Dialog().notification("MUBI", "Error: Unable to play DRM-protected content.", xbmcgui.NOTIFICATION_ERROR)
-
+        xbmcgui.Dialog().notification(
+            "MUBI", "Error: Unable to play DRM-protected content.", xbmcgui.NOTIFICATION_ERROR
+        )

--- a/repo/plugin_video_mubi/resources/lib/playback.py
+++ b/repo/plugin_video_mubi/resources/lib/playback.py
@@ -1,14 +1,16 @@
-import xbmcgui
-import xbmcplugin
-import inputstreamhelper
 import base64
 import json
 from urllib.parse import urlencode
+
+import inputstreamhelper
 import xbmc
-import pathlib
-from .mpd_patcher import MPDPatcher
+import xbmcgui
+import xbmcplugin
+
+from .constants import DRM_LICENSE_URL, MUBI_WEB_URL
 from .local_server import LocalServer
-from .constants import MUBI_WEB_URL, DRM_LICENSE_URL
+from .mpd_patcher import MPDPatcher
+
 
 def generate_drm_license_key(token, user_id):
     """

--- a/repo/plugin_video_mubi/resources/lib/session_manager.py
+++ b/repo/plugin_video_mubi/resources/lib/session_manager.py
@@ -1,5 +1,7 @@
 import random
+
 import xbmc
+
 
 class SessionManager:
     """

--- a/repo/plugin_video_mubi/resources/lib/session_manager.py
+++ b/repo/plugin_video_mubi/resources/lib/session_manager.py
@@ -16,11 +16,11 @@ class SessionManager:
         """
         self.plugin = plugin
         self.device_id = self.get_or_generate_device_id()
-        self.client_country = self._get_plugin_setting('client_country')
-        self.client_language = self._get_plugin_setting('accept-language')  # Initialize client language
-        self.token = self._get_plugin_setting('token')
+        self.client_country = self._get_plugin_setting("client_country")
+        self.client_language = self._get_plugin_setting("accept-language")  # Initialize client language
+        self.token = self._get_plugin_setting("token")
         self.is_logged_in = bool(self.token)
-        self.user_id = self._get_plugin_setting('userID')
+        self.user_id = self._get_plugin_setting("userID")
 
     def get_or_generate_device_id(self) -> str:
         """
@@ -29,15 +29,15 @@ class SessionManager:
         :return: The device ID.
         """
         try:
-            device_id = self._get_plugin_setting('deviceID')
+            device_id = self._get_plugin_setting("deviceID")
             if not device_id:
                 device_id = self.generate_device_id()
-                self.plugin.setSetting('deviceID', device_id)
+                self.plugin.setSetting("deviceID", device_id)
                 xbmc.log(f"Generated new device ID: {device_id}", xbmc.LOGDEBUG)
             return device_id
         except Exception as e:
             xbmc.log(f"Error retrieving or generating device ID: {e}", xbmc.LOGERROR)
-            return ''
+            return ""
 
     def generate_device_id(self) -> str:
         """
@@ -46,10 +46,12 @@ class SessionManager:
         :return: A newly generated device ID.
         """
         try:
-            return f"{self._code_gen(8)}-{self._code_gen(4)}-{self._code_gen(4)}-{self._code_gen(4)}-{self._code_gen(12)}"
+            return (
+                f"{self._code_gen(8)}-{self._code_gen(4)}-{self._code_gen(4)}-{self._code_gen(4)}-{self._code_gen(12)}"
+            )
         except Exception as e:
             xbmc.log(f"Error generating device ID: {e}", xbmc.LOGERROR)
-            return ''
+            return ""
 
     def _code_gen(self, length: int) -> str:
         """
@@ -59,11 +61,11 @@ class SessionManager:
         :return: Randomly generated hexadecimal string.
         """
         try:
-            base = '0123456789abcdef'
-            return ''.join(random.choice(base) for _ in range(length))
+            base = "0123456789abcdef"
+            return "".join(random.choice(base) for _ in range(length))
         except Exception as e:
             xbmc.log(f"Error generating random code: {e}", xbmc.LOGERROR)
-            return ''
+            return ""
 
     def set_logged_in(self, token: str, user_id: str):
         """
@@ -82,9 +84,9 @@ class SessionManager:
         try:
             # BUG #8 FIX: First, try all persistent operations before updating memory state
             # This ensures we can rollback if any operation fails
-            self.plugin.setSetting('token', token)
-            self.plugin.setSetting('userID', user_id)
-            self.plugin.setSettingBool('logged', True)
+            self.plugin.setSetting("token", token)
+            self.plugin.setSetting("userID", user_id)
+            self.plugin.setSettingBool("logged", True)
 
             # BUG #8 FIX: Only update memory state after all persistent operations succeed
             self.token = token
@@ -101,9 +103,9 @@ class SessionManager:
 
             # BUG #8 FIX: Also try to clear any partial persistent state that might have been set
             try:
-                self.plugin.setSetting('token', original_token or '')
-                self.plugin.setSetting('userID', original_user_id or '')
-                self.plugin.setSettingBool('logged', original_is_logged_in)
+                self.plugin.setSetting("token", original_token or "")
+                self.plugin.setSetting("userID", original_user_id or "")
+                self.plugin.setSettingBool("logged", original_is_logged_in)
             except Exception as rollback_error:
                 xbmc.log(f"Error during authentication rollback: {rollback_error}", xbmc.LOGWARNING)
 
@@ -113,7 +115,6 @@ class SessionManager:
             # BUG #8 FIX: Re-raise the exception so caller knows the operation failed
             raise
 
-
     def set_logged_out(self):
         """
         Set the logged-out state and clear the token and user ID from settings.
@@ -122,13 +123,13 @@ class SessionManager:
             self.token = None
             self.user_id = None  # Clear user ID
             self.is_logged_in = False
-            self.plugin.setSetting('token', '')
-            self.plugin.setSetting('userID', '')  # Clear user ID from settings
-            self.plugin.setSettingBool('logged', False)
+            self.plugin.setSetting("token", "")
+            self.plugin.setSetting("userID", "")  # Clear user ID from settings
+            self.plugin.setSettingBool("logged", False)
             xbmc.log("User logged out successfully.", xbmc.LOGDEBUG)
         except Exception as e:
             xbmc.log(f"Error setting logged-out status: {e}", xbmc.LOGERROR)
-            
+
     def set_client_country(self, client_country: str):
         """
         Set the client's country and save it to settings.
@@ -137,7 +138,7 @@ class SessionManager:
         """
         try:
             self.client_country = client_country
-            self.plugin.setSetting('client_country', client_country)
+            self.plugin.setSetting("client_country", client_country)
             xbmc.log(f"Client country set to {client_country}.", xbmc.LOGDEBUG)
         except Exception as e:
             xbmc.log(f"Error setting client country: {e}", xbmc.LOGERROR)
@@ -150,7 +151,7 @@ class SessionManager:
         """
         try:
             self.client_language = client_language
-            self.plugin.setSetting('accept-language', client_language)
+            self.plugin.setSetting("accept-language", client_language)
             xbmc.log(f"Client language set to {client_language}.", xbmc.LOGDEBUG)
         except Exception as e:
             xbmc.log(f"Error setting client language: {e}", xbmc.LOGERROR)
@@ -166,4 +167,4 @@ class SessionManager:
             return self.plugin.getSetting(setting_key)
         except Exception as e:
             xbmc.log(f"Error retrieving plugin setting '{setting_key}': {e}", xbmc.LOGERROR)
-            return ''
+            return ""


### PR DESCRIPTION
Closes #49.

## What

Adopts **ruff** as the linter/formatter for `repo/plugin_video_mubi` and `backend`, fixes every finding, and gates lint in CI.

Config (`pyproject.toml`): `select = ["E", "F", "W", "I"]`, `line-length = 120`, `target-version = "py38"`. `E501` is delegated to `ruff format` (which owns line length for code and won't split strings/URLs/comments — enforcing it on those is noise).

## Commits (review in order)

1. **`refactor: adopt ruff and fix all F/E/W/I lint findings`** — the reviewable, semantic diff. Unused/duplicate imports, f-strings without placeholders, 10 dead locals, `!= None` → `is not None`, a raw docstring for a literal backslash, `# noqa: E402` for two post-`sys.path` backend imports, import sorting.
2. **`refactor: apply ruff format`** — isolated mechanical reformat (whitespace, `E701`, quotes, wrapping). No behaviour change. Large but pure.
3. **`ci: gate ruff lint and format`** — a single `lint` job running `ruff check` + `ruff format --check`, ruff pinned to `0.16.6`.

## Acceptance criteria

- [x] `ruff check` clean on `repo/` and `backend/` (also `ruff format --check`).
- [x] CI fails on new lint violations (new `lint` job).
- [x] The format-only commit is isolated from logic changes (commit 2).

## Notes for the reviewer

- The 77 F-class findings the issue counted are all fixed. Safe categories (F401/F541/F811/I001) via ruff's fixer; the 10 `F841` unused variables reviewed by hand — all confirmed dead, **not** latent bugs (e.g. `mpaa_rating` is superseded by the backend `mpaa` field; `total_mubi_votes` by a median calc).
- One import removal (`library.xbmcaddon`) initially broke 3 concurrency tests that patch `library.xbmcaddon`. Fixed by keeping the module-level import and dropping the redundant *function-local* re-import, so the patch anchor survives.
- Two pre-existing behavioural oddities were left **as-is** (out of scope, would be behaviour changes): the worldwide-sync menu label is hardcoded `"about 2k films"` while ignoring the computed `total_films`; and a sync-failure path computes `error_title = "Sync Failed"` but the notification passes the hardcoded `"MUBI"` heading. Happy to file follow-ups.
- Scope is `repo/plugin_video_mubi` + `backend` per the issue. The root `tests/` tree is intentionally **not** gated here (separate concern).
- Full test suite green (796 passed, 17 pre-existing skips) before and after formatting.

Not user-visible (developer tooling); no README changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
