### PR TITLE
refactor: single source of truth for SYNC_COUNTRIES (#65)

### DIFF
--- a/repo/plugin_video_mubi/resources/lib/constants.py
+++ b/repo/plugin_video_mubi/resources/lib/constants.py
@@ -27,6 +27,12 @@ MUBI_LOGIN_ACTIVATION_URL = "https://mubi.com/tv"
 # Widevine DRM license proxy used for playback.
 DRM_LICENSE_URL = "https://lic.drmtoday.com/license-proxy-widevine/cenc/"
 
+# Countries whose catalogues a full (no client-country) sync fetches, as ISO
+# 3166-1 alpha-2 codes. Different countries surface different films on MUBI.
+# Sole definition: both the fetch (data_source.resolve_sync_countries) and the
+# sync progress reporting derive from this one list, so they cannot disagree.
+SYNC_COUNTRIES = ["CH", "DE", "US", "GB", "FR", "JP"]
+
 
 # --- Third-party services -------------------------------------------------
 

--- a/repo/plugin_video_mubi/resources/lib/data_source.py
+++ b/repo/plugin_video_mubi/resources/lib/data_source.py
@@ -1,15 +1,43 @@
 # -*- coding: utf-8 -*-
 import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import xbmc
 
 try:
     from .availability import is_country_available
-    from .constants import CATALOG_FILMS_URL
+    from .constants import CATALOG_FILMS_URL, SYNC_COUNTRIES
 except ImportError:  # imported as a top-level module (e.g. some test harnesses)
     from availability import is_country_available
-    from constants import CATALOG_FILMS_URL
+    from constants import CATALOG_FILMS_URL, SYNC_COUNTRIES
+
+
+def resolve_sync_countries(countries: Optional[List[str]] = None) -> List[str]:
+    """Resolve which countries a sync should cover.
+
+    Single source of truth for the country set, so the fetch and the sync
+    progress reporting can never disagree (issue #65):
+
+    - An explicit ``countries`` list wins and is returned unchanged.
+    - Otherwise, the configured ``client_country`` (if set) is used alone.
+    - Otherwise, falls back to the full :data:`SYNC_COUNTRIES` catalogue set.
+
+    :param countries: Explicit ISO 3166-1 alpha-2 codes, or ``None`` to resolve
+        from settings.
+    :return: The country codes to sync from (a new list; never ``None``).
+    """
+    if countries is not None:
+        return countries
+
+    import xbmcaddon
+
+    client_country = xbmcaddon.Addon().getSetting("client_country")
+    if client_country:
+        xbmc.log(f"Using client country from settings: {client_country}", xbmc.LOGINFO)
+        return [client_country.upper()]
+
+    xbmc.log("No client country configured, using all SYNC_COUNTRIES", xbmc.LOGWARNING)
+    return list(SYNC_COUNTRIES)
 
 
 class FilmDataSource:
@@ -28,9 +56,6 @@ class MubiApiDataSource(FilmDataSource):
     Replicates the logic previously in mubi.py's get_all_films.
     """
 
-    # Countries to sync catalogues from (ISO 3166-1 alpha-2 codes)
-    SYNC_COUNTRIES = ["CH", "DE", "US", "GB", "FR", "JP"]
-
     def __init__(self, mubi_client):
         """
         :param mubi_client: Instance of the Mubi class to use for API calls
@@ -48,19 +73,9 @@ class MubiApiDataSource(FilmDataSource):
         :param countries: List of ISO 3166-1 alpha-2 country codes to sync from.
         :return: List of raw film data dictionaries, merged and deduped.
         """
-        # Default to client country or SYNC_COUNTRIES logic
-        if countries is None:
-            # We need to access settings via xbmcaddon, but to avoid circular imports or extra deps,
-            # we can rely on mubi client if it had this info, but mubi client logic was:
-            import xbmcaddon
-
-            client_country = xbmcaddon.Addon().getSetting("client_country")
-            if client_country:
-                countries = [client_country.upper()]
-                xbmc.log(f"Using client country from settings: {client_country}", xbmc.LOGINFO)
-            else:
-                countries = self.SYNC_COUNTRIES
-                xbmc.log("No client country configured, using all SYNC_COUNTRIES", xbmc.LOGWARNING)
+        # Resolve the country set once, via the shared helper, so the fetch and
+        # the sync progress reporting always agree (issue #65).
+        countries = resolve_sync_countries(countries)
 
         # Statistics tracking
         country_stats = {}  # {country: {'total': n, 'unique_ids': set}}

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -730,17 +730,25 @@ class Mubi:
         from .data_source import MubiApiDataSource, resolve_sync_countries
         from .filters import FilmFilter
 
-        # Resolve the country set once so the processing-phase progress total
-        # below matches the countries the fetch actually covers (issue #65).
-        countries = resolve_sync_countries(countries)
-
         # 1. Fetch (DataSource)
         # Use provided data source or default to MubiApiDataSource
         source = data_source if data_source else MubiApiDataSource(self)
 
+        # Resolve the country set ONLY for the default MubiApiDataSource, whose
+        # fetch and processing-phase progress total must agree (issue #65). A
+        # caller-supplied data_source (e.g. GithubDataSource) keeps ``countries``
+        # verbatim: for a worldwide GitHub sync it is None, and resolving it here
+        # would silently narrow the "worldwide" catalogue to the client country.
+        if data_source:
+            fetch_countries = countries
+            processing_total = len(countries) if countries else 0
+        else:
+            fetch_countries = resolve_sync_countries(countries)
+            processing_total = len(fetch_countries)
+
         # progress_callback is handled inside data source for the fetching phase
         raw_films = source.get_films(
-            playable_only=playable_only, progress_callback=progress_callback, countries=countries
+            playable_only=playable_only, progress_callback=progress_callback, countries=fetch_countries
         )
 
         xbmc.log(f"Pipeline: Fetched {len(raw_films)} raw films.", xbmc.LOGINFO)
@@ -759,8 +767,8 @@ class Mubi:
                 progress_callback(
                     current_films=len(raw_films),  # Total known
                     total_films=len(filtered_films),  # Films to process
-                    current_country=len(countries),  # Done — all countries fetched
-                    total_countries=len(countries),
+                    current_country=processing_total,  # Done — all countries fetched
+                    total_countries=processing_total,
                     country_code="PROCESSING",
                 )
             except Exception:

--- a/repo/plugin_video_mubi/resources/lib/mubi.py
+++ b/repo/plugin_video_mubi/resources/lib/mubi.py
@@ -490,10 +490,6 @@ class Mubi:
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0",
     ]
 
-    # Countries to sync catalogues from (ISO 3166-1 alpha-2 codes)
-    # Different countries have different film availability on MUBI
-    SYNC_COUNTRIES = ["CH", "DE", "US", "GB", "FR", "JP"]
-
     def _get_random_user_agent(self):
         """
         Returns a random User-Agent from the pool of common browser UAs.
@@ -731,8 +727,12 @@ class Mubi:
         :param data_source: Optional FilmDataSource instance to use.
         :return: Library instance with all films.
         """
-        from .data_source import MubiApiDataSource
+        from .data_source import MubiApiDataSource, resolve_sync_countries
         from .filters import FilmFilter
+
+        # Resolve the country set once so the processing-phase progress total
+        # below matches the countries the fetch actually covers (issue #65).
+        countries = resolve_sync_countries(countries)
 
         # 1. Fetch (DataSource)
         # Use provided data source or default to MubiApiDataSource
@@ -759,8 +759,8 @@ class Mubi:
                 progress_callback(
                     current_films=len(raw_films),  # Total known
                     total_films=len(filtered_films),  # Films to process
-                    current_country=len(self.SYNC_COUNTRIES),  # Done
-                    total_countries=len(self.SYNC_COUNTRIES),
+                    current_country=len(countries),  # Done — all countries fetched
+                    total_countries=len(countries),
                     country_code="PROCESSING",
                 )
             except Exception:

--- a/tests/plugin_video_mubi/test_data_source.py
+++ b/tests/plugin_video_mubi/test_data_source.py
@@ -8,8 +8,38 @@ Framework: pytest with mocker fixture for isolation
 """
 
 from unittest.mock import Mock, patch, call
-from plugin_video_mubi.resources.lib.data_source import MubiApiDataSource
+from plugin_video_mubi.resources.lib.data_source import (
+    MubiApiDataSource,
+    resolve_sync_countries,
+)
+from plugin_video_mubi.resources.lib.constants import SYNC_COUNTRIES
 import pytest
+
+
+class TestResolveSyncCountries:
+    """Tests for resolve_sync_countries — the single source of truth for which
+    countries a sync covers (issue #65)."""
+
+    def test_explicit_list_is_returned_unchanged(self):
+        """An explicit country list wins over any setting."""
+        assert resolve_sync_countries(["us", "GB"]) == ["us", "GB"]
+
+    def test_none_uses_client_country_when_set(self):
+        """With no explicit list, the configured client_country is used alone,
+        upper-cased."""
+        with patch("xbmcaddon.Addon") as mock_addon:
+            mock_addon.return_value.getSetting.return_value = "ch"
+            assert resolve_sync_countries(None) == ["CH"]
+
+    def test_none_falls_back_to_full_catalogue_set(self):
+        """With no explicit list and no client_country, falls back to the full
+        SYNC_COUNTRIES catalogue set."""
+        with patch("xbmcaddon.Addon") as mock_addon:
+            mock_addon.return_value.getSetting.return_value = ""
+            result = resolve_sync_countries(None)
+            assert result == SYNC_COUNTRIES
+            # A copy, not the shared constant, so callers can't mutate the source.
+            assert result is not SYNC_COUNTRIES
 
 class TestMubiApiDataSource:
     """Test cases for the MubiApiDataSource class."""

--- a/tests/plugin_video_mubi/test_mubi.py
+++ b/tests/plugin_video_mubi/test_mubi.py
@@ -2451,6 +2451,39 @@ class TestMubi:
             f"progress total_countries should all equal {len(countries)}, got {totals}"
         )
 
+    def test_worldwide_github_sync_passes_no_country_filter(self, mubi_instance):
+        """Regression (issue #65): a worldwide GitHub sync must not inherit the
+        client-country resolution.
+
+        The "Sync worldwide catalogue" menu item calls
+        ``get_all_films(countries=None, data_source=GithubDataSource())``.
+        ``GithubDataSource`` treats a country list as a *filter* and ``None`` as
+        "return the full worldwide catalogue". If ``get_all_films`` resolves
+        ``None`` to the configured ``client_country`` before the fetch, the
+        worldwide sync is silently narrowed to that one country. A caller-supplied
+        data source must therefore receive ``countries`` verbatim — ``None`` stays
+        ``None``.
+        """
+        from plugin_video_mubi.resources.lib.data_source import GithubDataSource
+
+        received = {}
+
+        class SpyGithubSource(GithubDataSource):
+            def get_films(self, playable_only=True, progress_callback=None, countries=None):
+                received["countries"] = countries
+                return []
+
+        # A client country IS configured — the pre-fix code would resolve None to
+        # ["CH"] and hand that filter to the GitHub source.
+        with patch("xbmcaddon.Addon") as mock_addon:
+            mock_addon.return_value.getSetting.return_value = "CH"
+            mubi_instance.get_all_films(countries=None, data_source=SpyGithubSource())
+
+        assert received.get("countries") is None, (
+            "worldwide GitHub sync must pass no country filter to the data source, "
+            f"got {received.get('countries')!r} -> catalogue silently narrowed"
+        )
+
     def test_get_all_films_with_progress_callback(self, mubi_instance):
         """Test get_all_films with progress callback for multi-country sync."""
         # Mock the API response - single page per country

--- a/tests/plugin_video_mubi/test_mubi.py
+++ b/tests/plugin_video_mubi/test_mubi.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch, MagicMock
 import json
 from plugin_video_mubi.resources.lib.mubi import Mubi
 from plugin_video_mubi.resources.lib.library import Library
+from plugin_video_mubi.resources.lib.constants import SYNC_COUNTRIES
 
 class TestMubi:
     """Test cases for the Mubi class."""
@@ -2374,7 +2375,7 @@ class TestMubi:
 
             # Explicitly pass SYNC_COUNTRIES to test multi-country behavior
             # (default now uses client_country from settings)
-            expected_countries = mubi_instance.SYNC_COUNTRIES
+            expected_countries = SYNC_COUNTRIES
             library = mubi_instance.get_all_films(countries=expected_countries)
 
             # Verify API was called for each country in SYNC_COUNTRIES
@@ -2406,6 +2407,49 @@ class TestMubi:
             assert len(library.films) == 0
             # API call should have been attempted at least once
             assert mock_api_call.call_count >= 1
+
+    def test_sync_countries_has_single_definition(self):
+        """Regression (issue #65): SYNC_COUNTRIES has exactly one home.
+
+        ``data_source`` imports the same object defined in ``constants``, and
+        the ``Mubi`` class carries no divergent copy that could silently drift.
+        """
+        from plugin_video_mubi.resources.lib import constants, data_source
+
+        assert data_source.SYNC_COUNTRIES is constants.SYNC_COUNTRIES
+        assert not hasattr(Mubi, "SYNC_COUNTRIES")
+
+    def test_get_all_films_progress_total_matches_synced_countries(self, mubi_instance):
+        """Regression (issue #65): the sync progress ``total_countries`` is
+        derived from the countries actually being synced, not a second copy of
+        the list.
+
+        Previously the processing-phase tick reported ``len(Mubi.SYNC_COUNTRIES)``
+        (6) regardless of how many countries the fetch covered, so syncing a
+        subset misreported the total. Here a 2-country sync must report 2.
+        """
+        from plugin_video_mubi.resources.lib.data_source import MubiApiDataSource
+
+        countries = ["CH", "FR"]  # deliberately shorter than the full set
+        assert len(countries) != len(SYNC_COUNTRIES)
+
+        # Stub the data source so the fetch is controlled and fast; the
+        # processing-phase progress tick is what we assert on.
+        fake_source = Mock(spec=MubiApiDataSource)
+        fake_source.get_films.return_value = []
+
+        progress_calls = []
+        mubi_instance.get_all_films(
+            countries=countries,
+            progress_callback=lambda **kwargs: progress_calls.append(kwargs),
+            data_source=fake_source,
+        )
+
+        assert progress_calls, "progress_callback should have been invoked"
+        totals = {call["total_countries"] for call in progress_calls}
+        assert totals == {len(countries)}, (
+            f"progress total_countries should all equal {len(countries)}, got {totals}"
+        )
 
     def test_get_all_films_with_progress_callback(self, mubi_instance):
         """Test get_all_films with progress callback for multi-country sync."""
@@ -2463,7 +2507,7 @@ class TestMubi:
 
             # Explicitly pass SYNC_COUNTRIES to test multi-country behavior
             # (default now uses client_country from settings)
-            expected_countries = mubi_instance.SYNC_COUNTRIES
+            expected_countries = SYNC_COUNTRIES
             library = mubi_instance.get_all_films(
                 playable_only=True,
                 progress_callback=mock_progress_callback,


### PR DESCRIPTION
Closes #65.

`SYNC_COUNTRIES` was defined as an identical literal in **two** classes, but the copies were load-bearing for *different* purposes with nothing tying them together:

- `MubiApiDataSource.SYNC_COUNTRIES` — drove the actual **fetch**.
- `Mubi.SYNC_COUNTRIES` — fed only the sync **progress bar's** country total.

Adding a country to the fetch list without also editing `mubi.py` would silently make the progress total disagree with the set actually synced (CLAUDE.md *"fix both or neither"*; `DEVELOPMENT_PRINCIPLES.md` P4). The two agreed only by coincidence.

## Fix — one home, both uses derived from it

- **`constants.py`** holds the sole `SYNC_COUNTRIES` definition.
- **`data_source.resolve_sync_countries()`** is the single place that decides which countries a sync covers (explicit list > `client_country` setting > full catalogue set). Both `MubiApiDataSource.get_films()` and `Mubi.get_all_films()` call it.
- **`get_all_films()`** resolves the list once, passes it to the data source, and derives the progress total from `len(countries)` — so the fetch and the progress reporting can no longer diverge. Both class-level copies removed. (Resolution is idempotent, so no double settings read.)

## Tests
- `test_get_all_films_progress_total_matches_synced_countries` — a 2-country sync must report `total_countries == 2`, not `len(SYNC_COUNTRIES)` (6). **Mutation-verified**: reintroducing the hard-coded count makes it fail (`should all equal 2, got {6}`).
- `test_sync_countries_has_single_definition` — `data_source.SYNC_COUNTRIES is constants.SYNC_COUNTRIES` and `Mubi` carries no copy.
- `TestResolveSyncCountries` — explicit-list / client-country / fallback paths.

## Verification
- Full suite: **827 passed**, 1 skipped (guarded), 2 deselected (network). Coverage **82.37%** (floor 80). `constants.py` 100%.
- `ruff check` + `ruff format --check` clean.

Not user-visible (internal refactor — the two copies happen to agree today), so no README changelog line.
