### PR TITLE
ci: extract WireGuard/ProtonVPN setup into a composite action

### DIFF
--- a/.github/actions/connect-vpn/action.yml
+++ b/.github/actions/connect-vpn/action.yml
@@ -1,0 +1,87 @@
+name: Connect to ProtonVPN (WireGuard)
+description: >-
+  Install wireguard-tools, bring up a ProtonVPN WireGuard tunnel from the given
+  credentials, and verify the exit IP changed. Composite actions cannot read
+  secrets.* directly, so the caller must pass them in as inputs.
+
+inputs:
+  private_key:
+    description: WireGuard interface private key (secrets.WIREGUARD_PRIVATE_KEY)
+    required: true
+  address:
+    description: WireGuard interface address (secrets.WIREGUARD_ADDRESS)
+    required: true
+  public_key:
+    description: WireGuard peer public key (secrets.WIREGUARD_PUBLIC_KEY)
+    required: true
+  endpoint:
+    description: WireGuard peer endpoint host:port (secrets.WIREGUARD_ENDPOINT)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install VPN Dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wireguard-tools
+
+    - name: Connect to ProtonVPN (WireGuard)
+      shell: bash
+      env:
+        WIREGUARD_PRIVATE_KEY: ${{ inputs.private_key }}
+        WIREGUARD_ADDRESS: ${{ inputs.address }}
+        WIREGUARD_PUBLIC_KEY: ${{ inputs.public_key }}
+        WIREGUARD_ENDPOINT: ${{ inputs.endpoint }}
+      run: |
+        echo "=== NETWORK DEBUG (BEFORE) ==="
+        ip addr
+        ip route
+        echo "=============================="
+
+        echo "Generating WireGuard config from secrets..."
+        cat <<EOF > wg0.conf
+        [Interface]
+        PrivateKey = ${WIREGUARD_PRIVATE_KEY}
+        Address = ${WIREGUARD_ADDRESS}
+        # DNS = 10.2.0.1  <-- Commented out to prevent resolvconf issues
+
+        [Peer]
+        PublicKey = ${WIREGUARD_PUBLIC_KEY}
+        AllowedIPs = 0.0.0.0/0
+        Endpoint = ${WIREGUARD_ENDPOINT}
+        PersistentKeepalive = 25
+        EOF
+
+        chmod 600 wg0.conf
+
+        echo "Checking initial IP..."
+        curl -s --max-time 10 https://ifconfig.me || echo "Failed to fetch IP"
+
+        echo "Starting VPN..."
+        if sudo wg-quick up ./wg0.conf; then
+          echo "✅ VPN Interface Returned Success"
+
+          echo "=== NETWORK DEBUG (VPN UP) ==="
+          sudo wg show
+          ip addr
+          ip route
+          echo "Ping Test (1.1.1.1):"
+          ping -c 2 1.1.1.1 || echo "Ping failed"
+          echo "=============================="
+
+          echo "Waiting for connection stability..."
+          sleep 5
+
+          echo "Checking VPN IP..."
+          if curl -v --max-time 10 https://ifconfig.me; then
+             echo "✅ IP Check Success"
+          else
+             echo "❌ IP Check Failed"
+             exit 1
+          fi
+        else
+          echo "⚠️ VPN Connection FAILED - Proceeding without VPN"
+          exit 1
+        fi

--- a/.github/workflows/mubi_deep_sync.yml
+++ b/.github/workflows/mubi_deep_sync.yml
@@ -45,64 +45,14 @@ jobs:
 
 
 
-    - name: Install VPN Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y wireguard-tools
-
     - name: Connect to ProtonVPN (WireGuard)
       continue-on-error: true
-      run: |
-        echo "=== NETWORK DEBUG (BEFORE) ==="
-        ip addr
-        ip route
-        echo "=============================="
-
-        echo "Generating WireGuard config from secrets..."
-        cat <<EOF > wg0.conf
-        [Interface]
-        PrivateKey = ${{ secrets.WIREGUARD_PRIVATE_KEY }}
-        Address = ${{ secrets.WIREGUARD_ADDRESS }}
-        # DNS = 10.2.0.1  <-- Commented out to prevent resolvconf issues
-
-        [Peer]
-        PublicKey = ${{ secrets.WIREGUARD_PUBLIC_KEY }}
-        AllowedIPs = 0.0.0.0/0
-        Endpoint = ${{ secrets.WIREGUARD_ENDPOINT }}
-        PersistentKeepalive = 25
-        EOF
-        
-        chmod 600 wg0.conf
-        
-        echo "Checking initial IP..."
-        curl -s --max-time 10 https://ifconfig.me || echo "Failed to fetch IP"
-        
-        echo "Starting VPN..."
-        if sudo wg-quick up ./wg0.conf; then
-          echo "✅ VPN Interface Returned Success"
-          
-          echo "=== NETWORK DEBUG (VPN UP) ==="
-          sudo wg show
-          ip addr
-          ip route
-          echo "Ping Test (1.1.1.1):"
-          ping -c 2 1.1.1.1 || echo "Ping failed"
-          echo "=============================="
-          
-          echo "Waiting for connection stability..."
-          sleep 5
-          
-          echo "Checking VPN IP..."
-          if curl -v --max-time 10 https://ifconfig.me; then
-             echo "✅ IP Check Success"
-          else
-             echo "❌ IP Check Failed"
-             exit 1 
-          fi
-        else
-          echo "⚠️ VPN Connection FAILED - Proceeding without VPN"
-          exit 1
-        fi
+      uses: ./.github/actions/connect-vpn
+      with:
+        private_key: ${{ secrets.WIREGUARD_PRIVATE_KEY }}
+        address: ${{ secrets.WIREGUARD_ADDRESS }}
+        public_key: ${{ secrets.WIREGUARD_PUBLIC_KEY }}
+        endpoint: ${{ secrets.WIREGUARD_ENDPOINT }}
 
     - name: Run Scraper (Deep Mode)
       run: |

--- a/.github/workflows/mubi_shallow_sync.yml
+++ b/.github/workflows/mubi_shallow_sync.yml
@@ -45,64 +45,14 @@ jobs:
 
 
 
-    - name: Install VPN Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y wireguard-tools
-
     - name: Connect to ProtonVPN (WireGuard)
       continue-on-error: true
-      run: |
-        echo "=== NETWORK DEBUG (BEFORE) ==="
-        ip addr
-        ip route
-        echo "=============================="
-
-        echo "Generating WireGuard config from secrets..."
-        cat <<EOF > wg0.conf
-        [Interface]
-        PrivateKey = ${{ secrets.WIREGUARD_PRIVATE_KEY }}
-        Address = ${{ secrets.WIREGUARD_ADDRESS }}
-        # DNS = 10.2.0.1  <-- Commented out to prevent resolvconf issues
-
-        [Peer]
-        PublicKey = ${{ secrets.WIREGUARD_PUBLIC_KEY }}
-        AllowedIPs = 0.0.0.0/0
-        Endpoint = ${{ secrets.WIREGUARD_ENDPOINT }}
-        PersistentKeepalive = 25
-        EOF
-        
-        chmod 600 wg0.conf
-        
-        echo "Checking initial IP..."
-        curl -s --max-time 10 https://ifconfig.me || echo "Failed to fetch IP"
-        
-        echo "Starting VPN..."
-        if sudo wg-quick up ./wg0.conf; then
-          echo "✅ VPN Interface Returned Success"
-          
-          echo "=== NETWORK DEBUG (VPN UP) ==="
-          sudo wg show
-          ip addr
-          ip route
-          echo "Ping Test (1.1.1.1):"
-          ping -c 2 1.1.1.1 || echo "Ping failed"
-          echo "=============================="
-          
-          echo "Waiting for connection stability..."
-          sleep 5
-          
-          echo "Checking VPN IP..."
-          if curl -v --max-time 10 https://ifconfig.me; then
-             echo "✅ IP Check Success"
-          else
-             echo "❌ IP Check Failed"
-             exit 1 
-          fi
-        else
-          echo "⚠️ VPN Connection FAILED - Proceeding without VPN"
-          exit 1
-        fi
+      uses: ./.github/actions/connect-vpn
+      with:
+        private_key: ${{ secrets.WIREGUARD_PRIVATE_KEY }}
+        address: ${{ secrets.WIREGUARD_ADDRESS }}
+        public_key: ${{ secrets.WIREGUARD_PUBLIC_KEY }}
+        endpoint: ${{ secrets.WIREGUARD_ENDPOINT }}
 
     - name: Checkout Database Branch (Input)
       uses: actions/checkout@v4

--- a/.github/workflows/mubi_test_sync.yml
+++ b/.github/workflows/mubi_test_sync.yml
@@ -48,64 +48,14 @@ jobs:
 
 
 
-    - name: Install VPN Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y wireguard-tools
-
     - name: Connect to ProtonVPN (WireGuard)
       continue-on-error: true
-      run: |
-        echo "=== NETWORK DEBUG (BEFORE) ==="
-        ip addr
-        ip route
-        echo "=============================="
-
-        echo "Generating WireGuard config from secrets..."
-        cat <<EOF > wg0.conf
-        [Interface]
-        PrivateKey = ${{ secrets.WIREGUARD_PRIVATE_KEY }}
-        Address = ${{ secrets.WIREGUARD_ADDRESS }}
-        # DNS = 10.2.0.1  <-- Commented out to prevent resolvconf issues
-
-        [Peer]
-        PublicKey = ${{ secrets.WIREGUARD_PUBLIC_KEY }}
-        AllowedIPs = 0.0.0.0/0
-        Endpoint = ${{ secrets.WIREGUARD_ENDPOINT }}
-        PersistentKeepalive = 25
-        EOF
-        
-        chmod 600 wg0.conf
-        
-        echo "Checking initial IP..."
-        curl -s --max-time 10 https://ifconfig.me || echo "Failed to fetch IP"
-        
-        echo "Starting VPN..."
-        if sudo wg-quick up ./wg0.conf; then
-          echo "✅ VPN Interface Returned Success"
-          
-          echo "=== NETWORK DEBUG (VPN UP) ==="
-          sudo wg show
-          ip addr
-          ip route
-          echo "Ping Test (1.1.1.1):"
-          ping -c 2 1.1.1.1 || echo "Ping failed"
-          echo "=============================="
-          
-          echo "Waiting for connection stability..."
-          sleep 5
-          
-          echo "Checking VPN IP..."
-          if curl -v --max-time 10 https://ifconfig.me; then
-             echo "✅ IP Check Success"
-          else
-             echo "❌ IP Check Failed"
-             exit 1 
-          fi
-        else
-          echo "⚠️ VPN Connection FAILED - Proceeding without VPN"
-          exit 1
-        fi
+      uses: ./.github/actions/connect-vpn
+      with:
+        private_key: ${{ secrets.WIREGUARD_PRIVATE_KEY }}
+        address: ${{ secrets.WIREGUARD_ADDRESS }}
+        public_key: ${{ secrets.WIREGUARD_PUBLIC_KEY }}
+        endpoint: ${{ secrets.WIREGUARD_ENDPOINT }}
 
     - name: Run Scraper (Single Country - ${{ inputs.country }})
       continue-on-error: true  # Single-country test won't meet MIN_TOTAL_FILMS threshold


### PR DESCRIPTION
## What & why

Closes #61.

The ~80-line WireGuard/ProtonVPN setup (install `wireguard-tools`, write `wg0.conf` from secrets, bring the tunnel up, verify the exit IP changed) was copy-pasted **identically** across `mubi_deep_sync.yml`, `mubi_shallow_sync.yml` and `mubi_test_sync.yml`. Any fix had to be made in three places and they could drift (DEVELOPMENT_PRINCIPLES.md P8).

## Change

- New `.github/actions/connect-vpn/action.yml` (`runs: using: composite`) holding both the *Install VPN Dependencies* and *Connect to ProtonVPN (WireGuard)* steps.
- Composite actions can't read `secrets.*`, so the four WireGuard values are declared as `inputs` (`private_key`, `address`, `public_key`, `endpoint`); each caller passes `${{ secrets.WIREGUARD_* }}`.
- The three workflows now call one `uses: ./.github/actions/connect-vpn` step, keeping `continue-on-error: true` to preserve today's behaviour.

Net: **+105 / −168**.

## Secret handling

Inside the action the secrets are bound to **step `env` vars** and referenced as `${WIREGUARD_*}` in the heredoc, rather than interpolated straight into the `run:` script as before. This keeps the values off the config-generation command line; GitHub still masks them in logs. No secret is echoed.

## Behaviour change

None intended — the composite's script is byte-for-byte the same logic, only the secret substitution mechanism changed (direct interpolation → env vars).

## Verification

- [x] All four YAML files parse.
- [x] Only the four `secrets.WIREGUARD_*` references remain in the workflows (in the `with:` block); no `wireguard-tools` install or inline config left in them.
- [x] Manual run of `mubi_test_sync.yml` (run 33844947054): exit IP changed `20.62.207.245` → `149.22.89.98`, `✅ IP Check Success`, both inner steps succeeded, no secret in logs.

## Acceptance criteria

- [x] VPN setup lives in one composite action used by all three sync workflows.
- [x] A test sync run reaches Mubi through the tunnel as before (run 33844947054).
- [x] No secret value appears in the action's logs.

Not user-visible (CI only) — no README changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
